### PR TITLE
Use resolveObject feature for policy directive on object type

### DIFF
--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -152,5 +152,4 @@ In the example above, the `roles` argument value is received by using the Argume
 
 **_Important!_** The [order of directives](https://github.com/graphql/graphql-spec/blob/master/spec/Section%202%20--%20Language.md#directives) does matter! The directives are applied in order they appear in schema. Object type directives are applied before field definition directives.
 
-The `@policy` directive (that can be set either on object type or field definition) is implemented so that the policy requirements are tested before all other directive resolvers, regardless of the order of directives.
-It's recommended to set the `@policy` directive the last one for readability reasons.
+The `@policy` directive is required to be set **the last** either on object type or field definition.

--- a/services/src/modules/directives/policy/policy.ts
+++ b/services/src/modules/directives/policy/policy.ts
@@ -1,101 +1,44 @@
-/**
- * This module implements @policy directive
- * The policy directive is implemented by replacing the original field.resolve with the new one that is the wrapping of
- * the original field.resolve method with the policy check before invocation.
- * If the policy returns allow=false response the original method isn't invoked.
- *
- * Note: field.resolve method can be changed by some other factors. (Another directives, extensions, plugins and etc.)
- * The order of the application of these changes is critical for the right request execution.
- *
- * The order is as following:
- * 1) Object type directives (ordered as are set in SDL)
- * 2) Field definition directives (ordered as are set in SDL)
- * 3) Apollo Server Core features (like extensions and plugins)
- *
- * This poses great challenges for the @policy directive implementation.
- * It should wrap the field.resolve method but the method implementation sometimes will be defined after the directive
- * attach event is already proceeded.
- * On other hand the wrapping created by the @policy directive can be wrapped by the extension mechanism of Apollo
- * Server.
- *
- * So the directive is implemented by using twe different tricks.
- * 1) Change field."resolve" from property to property accessor. This allows to handle the code that replaces the
- * "resolve" method after the directory was attached. (See visitFieldDefinition method of PolicyDirective class)
- *
- * 2) The getter of "resolve" property will return Proxy of the "resolve" function. The Proxy will change the apply
- * behavior of the function. Instead of just call the function, the policy check will be done and only if it will pass
- * the function will be called. (See createProxyHandler function)
- *
- * The wrapping with the policy check done in the Proxy so it isn't affected by the "resolve" method replacement on one
- * hand and doesn't affects the wrappings done by other parts of the server
- */
-
-import {
-  GraphQLResolveInfo,
-  GraphQLField,
-  defaultFieldResolver,
-  GraphQLObjectType,
-  GraphQLFieldResolver,
-} from 'graphql';
+import { GraphQLResolveInfo, GraphQLField, defaultFieldResolver, GraphQLObjectType, FieldNode } from 'graphql';
 import { SchemaDirectiveVisitor } from 'graphql-tools';
 import { gql } from 'apollo-server-core';
 import { RequestContext } from '../../context';
 import { GraphQLArguments, Policy } from './types';
 
-type ResolveFunction = GraphQLFieldResolver<unknown, RequestContext, { [k: string]: unknown }>;
-type GraphQLFieldExt = GraphQLField<unknown, RequestContext, Record<string, any>> & {
-  internalResolve: ResolveFunction;
-};
-
-/** Using Proxy for resolve function instead of regular wrapping as in @stub or @rest directives ensures that
- * the wrapping will be transparent for get/set operation on the "resolve" property
- */
-const createProxyHandler = (policy: Policy): ProxyHandler<ResolveFunction> => ({
-  apply: async function (target: ResolveFunction, _thisArg: GraphQLFieldExt, argumentsList: unknown[]) {
-    const parent: unknown = argumentsList[0];
-    const args: GraphQLArguments = argumentsList[1] as GraphQLArguments;
-    const context: RequestContext = argumentsList[2] as RequestContext;
-    const info: GraphQLResolveInfo = argumentsList[3] as GraphQLResolveInfo;
-
-    if (!context.ignorePolicies) {
-      await context.policyExecutor.validatePolicy(policy, parent, args, context, info);
-    }
-
-    return target(parent, args, context, info);
-  },
-});
-
 export class PolicyDirective extends SchemaDirectiveVisitor {
   visitObject(object: GraphQLObjectType<unknown, RequestContext>) {
-    const fields = object.getFields();
-    const fieldDefinitions = object.astNode?.fields;
+    const policy = this.args as Policy;
+    const originalResolveObject = object.resolveObject;
 
-    if (fieldDefinitions) {
-      for (const fd of fieldDefinitions) {
-        if (!fd.directives?.some(dd => dd.name.value === 'policy')) {
-          const field = fields[fd.name.value];
-          this.visitFieldDefinition(field);
-        }
+    object.resolveObject = async (
+      source: unknown,
+      fields: Record<string, ReadonlyArray<FieldNode>>,
+      context: RequestContext,
+      info: GraphQLResolveInfo
+    ) => {
+      if (!context.ignorePolicies) {
+        await context.policyExecutor.validatePolicy(policy, source, {}, context, info);
       }
-    }
+
+      return originalResolveObject ? await originalResolveObject(source, fields, context, info) : source;
+    };
   }
 
   visitFieldDefinition(field: GraphQLField<unknown, RequestContext>) {
-    const handler = createProxyHandler(this.args as Policy);
-
+    const policy = this.args as Policy;
     const originalResolve = field.resolve || defaultFieldResolver;
 
-    /** property replaced with property accessor to store the original "resolve" logic (event if it will be set later) */
-    Object.defineProperty(field, 'resolve', {
-      set: (newResolve: ResolveFunction) => {
-        (field as GraphQLFieldExt).internalResolve = newResolve;
-      },
-      get: () => {
-        return new Proxy((field as GraphQLFieldExt).internalResolve, handler);
-      },
-    });
+    field.resolve = async (
+      source: unknown,
+      args: GraphQLArguments,
+      context: RequestContext,
+      info: GraphQLResolveInfo
+    ) => {
+      if (!context.ignorePolicies) {
+        await context.policyExecutor.validatePolicy(policy, source, args, context, info);
+      }
 
-    field.resolve = originalResolve;
+      return originalResolve.call(field, source, args, context, info);
+    };
   }
 }
 

--- a/services/tests/integration/gateway/__snapshots__/policy-directive.spec.ts.snap
+++ b/services/tests/integration/gateway/__snapshots__/policy-directive.spec.ts.snap
@@ -64,6 +64,38 @@ exports[`Policy Directive Tests LowerCase, policy on object, stub on parent quer
 }
 `;
 
+exports[`Policy Directive Tests Mock, policy on object, stub on parent query (ALLOW) 1`] = `
+Object {
+  "data": Object {
+    "foo": Object {
+      "bar": "BAR: 1",
+    },
+  },
+  "errors": undefined,
+  "extensions": undefined,
+  "http": Object {
+    "headers": Headers {
+      Symbol(map): Object {},
+    },
+  },
+}
+`;
+
+exports[`Policy Directive Tests Mock, policy on object, stub on parent query (DENY) 1`] = `
+{
+  "errors": [
+    {
+      "name": "GraphQLError",
+      "message": "Error",
+      "exception": {
+        "code": "INTERNAL_SERVER_ERROR"
+      }
+    }
+  ],
+  "data": {}
+}
+`;
+
 exports[`Policy Directive Tests Policy on field, resolver on object (ALLOW) 1`] = `
 Object {
   "data": Object {
@@ -227,17 +259,19 @@ Object {
 `;
 
 exports[`Policy Directive Tests Policy, stub on field (DENY) 1`] = `
-{
-  "errors": [
-    {
-      "name": "GraphQLError",
-      "message": "Error",
-      "exception": {
-        "code": "INTERNAL_SERVER_ERROR"
-      }
-    }
-  ],
-  "data": {}
+Object {
+  "data": Object {
+    "foo": Object {
+      "bar": "BAR",
+    },
+  },
+  "errors": undefined,
+  "extensions": undefined,
+  "http": Object {
+    "headers": Headers {
+      Symbol(map): Object {},
+    },
+  },
 }
 `;
 

--- a/services/tests/integration/utils/mock-directive.ts
+++ b/services/tests/integration/utils/mock-directive.ts
@@ -1,0 +1,27 @@
+import { SchemaDirectiveVisitor } from 'graphql-tools';
+import { GraphQLField, GraphQLObjectType } from 'graphql';
+import { gql } from 'apollo-server-core';
+
+export class MockDirective extends SchemaDirectiveVisitor {
+  visitObject(object: GraphQLObjectType<{ id: string }, unknown>) {
+    object.resolveObject = source => {
+      const { id } = source;
+      return {
+        bar: `BAR: ${id}`,
+      };
+    };
+  }
+
+  visitFieldDefinition(field: GraphQLField<{ id: string }, unknown>) {
+    field.resolve = source => {
+      const { id } = source;
+      return {
+        bar: `BAR: ${id}`,
+      };
+    };
+  }
+}
+
+export const sdl = gql`
+  directive @mock on OBJECT | FIELD_DEFINITION
+`;


### PR DESCRIPTION
This is `policy` directive implementation using `resolveObject` experimental feature of Apollo.
It should be introduced officially in next major version.