### PR TITLE
Arguments injection - return template "as is" on evaluation fail

### DIFF
--- a/services/src/modules/arguments-injection/arguments-evaluation.spec.ts
+++ b/services/src/modules/arguments-injection/arguments-evaluation.spec.ts
@@ -70,6 +70,14 @@ const testCases: [string, TestCase][] = [
       expected: { foo: 'Foo', bar: 'Bar', baz: '{ "foo": "FOO", "bar": { "baz": "BAZ" } }' },
     },
   ],
+  [
+    'Return value if not valid',
+    {
+      template: '{{ foo, bar }',
+      data: { foo: 'Foo', bar: 'Bar' },
+      expected: '{{ foo, bar }',
+    },
+  ],
 ];
 
 describe('Argument Injection Tests - Evaluation', () => {

--- a/services/src/modules/arguments-injection/arguments-evaluation.ts
+++ b/services/src/modules/arguments-injection/arguments-evaluation.ts
@@ -4,14 +4,18 @@ const exprStart = /{/g;
 const fullCapture = /(^{[^{]+}$)|(^{{.+}}$)/g;
 
 function evaluate<T>(template: string, data?: Record<string, unknown>): T {
-  const vm = new VM().setGlobals(data);
-  const fullMatch = template.match(fullCapture);
-  if (fullMatch) {
-    return vm.run(`(function evaluate() { return ${template.slice(1, -1)}; })()`);
-  }
+  try {
+    const vm = new VM().setGlobals(data);
+    const fullMatch = template.match(fullCapture);
+    if (fullMatch) {
+      return vm.run(`(function evaluate() { return ${template.slice(1, -1)}; })()`);
+    }
 
-  const expression = template.replace(exprStart, '${');
-  return vm.run(`\`${expression}\``);
+    const expression = template.replace(exprStart, '${');
+    return vm.run(`\`${expression}\``);
+  } catch {
+    return (template as unknown) as T;
+  }
 }
 
 export default evaluate;


### PR DESCRIPTION
This PR fixes the case when the string sent to argument-injection module wasn't supposed to be evaluated but matches regexp. In this case the evaluation fails. So the original template will be return.