### PR TITLE
Caching JWK

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -28,9 +28,9 @@ Usually only `/graphql` endpoint should be protected by non-anonymous strategy. 
 {
   "jwt": {
     "<<< JWT issuer >>>": {
-      "jwkUrl": "<<< Oidc Provider's JWKs Endpoint >>>",
+      "jwksUri": "<<< Oidc Provider's JWKs Endpoint >>>",
       // Audience is optional field and will be validated only if defined. See below another way to validate audience using policies.
-      "audience": "<<Stitch audience>>"
+      "audience": "<<Stitch audience>>",
       "authenticatedPaths": ["/graphql"]
     }
   },

--- a/services/src/modules/authentication/strategies/jwt.ts
+++ b/services/src/modules/authentication/strategies/jwt.ts
@@ -30,6 +30,7 @@ export default async function (request: fastify.FastifyRequest): Promise<void> {
     try {
       // Verify JWT signing, expiration and more
       await request.jwtVerify();
+      logger.trace({ issuer }, 'JWT verified');
     } catch (error) {
       logger.debug(error, 'Failed to verify request JWT');
       throw new Error('Unauthorized');

--- a/services/src/modules/authentication/types.ts
+++ b/services/src/modules/authentication/types.ts
@@ -1,5 +1,5 @@
 export interface IssuerConfig {
-  jwkUrl: string;
+  jwksUri: string;
   audience?: string;
   authenticatedPaths: string[];
 }

--- a/services/src/modules/logger.ts
+++ b/services/src/modules/logger.ts
@@ -8,7 +8,7 @@ const loggerConfig: pino.LoggerOptions = {
 };
 
 const devLoggerConfig: pino.LoggerOptions = {
-  level: 'debug',
+  level: 'trace',
   prettyPrint: {
     colorize: true,
     translateTime: 'HH:MM:ss',

--- a/services/tests/e2e/authentication/__snapshots__/verify-jwt.spec.ts.snap
+++ b/services/tests/e2e/authentication/__snapshots__/verify-jwt.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Authentication - Verify JWT Invalid JWT token 1`] = `
+exports[`Authentication - Verify JWT Invalid JWT 1`] = `
 Object {
   "error": "Unauthorized",
   "message": "Unauthorized",
@@ -9,12 +9,39 @@ Object {
 }
 `;
 
-exports[`Authentication - Verify JWT Invalid JWT token: gateway logs 1`] = `
+exports[`Authentication - Verify JWT Invalid JWT: gateway logs 1`] = `
 "**** START OUTPUT CAPTURE *****\\"
-[hh:mm:ss] [31mERROR[39m (SigningKeyNotFoundError): [36mFailed to get JWK for request token.[39m
+[hh:mm:ss] ERROR: Failed to get JWK for request token.
+    err: {
+      \\"type\\": \\"SigningKeyNotFoundError\\",
+      \\"message\\": \\"Unable to find a signing key that matches 'C1B59DF60057CFB292C4E36CCE329615'\\",
+      \\"stack\\":
+          SigningKeyNotFoundError: Unable to find a signing key that matches 'C1B59DF60057CFB292C4E36CCE329615'
+      \\"name\\": \\"SigningKeyNotFoundError\\"
+    }
+    jwksUri: \\"http://oidc-server-mock/.well-known/openid-configuration/jwks\\"
+[hh:mm:ss] DEBUG (SigningKeyNotFoundError): Failed to verify request JWT
     SigningKeyNotFoundError: Unable to find a signing key that matches 'C1B59DF60057CFB292C4E36CCE329615'
-[hh:mm:ss] [34mDEBUG[39m (SigningKeyNotFoundError): [36mFailed to verify request JWT[39m
-    SigningKeyNotFoundError: Unable to find a signing key that matches 'C1B59DF60057CFB292C4E36CCE329615'
+\\"***** END OUTPUT CAPTURE *****"
+`;
+
+exports[`Authentication - Verify JWT Second call with valid JWT - JWKs caching 1`] = `
+Object {
+  "jwt_foo": "FOO",
+}
+`;
+
+exports[`Authentication - Verify JWT Second call with valid JWT - JWKs caching: gateway logs 1`] = `
+"**** START OUTPUT CAPTURE *****\\"
+[hh:mm:ss] TRACE: JWK found
+    jwksUri: \\"http://oidc-server-mock/.well-known/openid-configuration/jwks\\"
+[hh:mm:ss] TRACE: JWT verified
+    issuer: \\"http://localhost:8070\\"
+[hh:mm:ss] TRACE: Started to handle request
+    query: \\"{\\\\n  jwt_foo\\\\n}\\\\n\\"
+[hh:mm:ss] TRACE: Finished to handle request
+    query: \\"{\\\\n  jwt_foo\\\\n}\\\\n\\"
+    durationMs: XXX
 \\"***** END OUTPUT CAPTURE *****"
 `;
 
@@ -29,7 +56,7 @@ Object {
 
 exports[`Authentication - Verify JWT Unexpected audience: gateway logs 1`] = `
 "**** START OUTPUT CAPTURE *****\\"
-[hh:mm:ss] [34mDEBUG[39m: [36mUnexpected audience[39m
+[hh:mm:ss] DEBUG: Unexpected audience
     issuer: \\"http://localhost:8070\\"
     audience: \\"Stitch Other\\"
 \\"***** END OUTPUT CAPTURE *****"
@@ -46,18 +73,29 @@ Object {
 
 exports[`Authentication - Verify JWT Unknown issuer: gateway logs 1`] = `
 "**** START OUTPUT CAPTURE *****\\"
-[hh:mm:ss] [34mDEBUG[39m: [36mUnknown issuer[39m
+[hh:mm:ss] DEBUG: Unknown issuer
     issuer: \\"http://microsoft.com\\"
 \\"***** END OUTPUT CAPTURE *****"
 `;
 
-exports[`Authentication - Verify JWT Valid JWT token 1`] = `
+exports[`Authentication - Verify JWT Valid JWT 1`] = `
 Object {
   "jwt_foo": "FOO",
 }
 `;
 
-exports[`Authentication - Verify JWT Valid JWT token: gateway logs 1`] = `
+exports[`Authentication - Verify JWT Valid JWT: gateway logs 1`] = `
 "**** START OUTPUT CAPTURE *****\\"
+[hh:mm:ss] DEBUG: New JWK received. Creating new client...
+    jwksUri: \\"http://oidc-server-mock/.well-known/openid-configuration/jwks\\"
+[hh:mm:ss] TRACE: JWK found
+    jwksUri: \\"http://oidc-server-mock/.well-known/openid-configuration/jwks\\"
+[hh:mm:ss] TRACE: JWT verified
+    issuer: \\"http://localhost:8070\\"
+[hh:mm:ss] TRACE: Started to handle request
+    query: \\"{\\\\n  jwt_foo\\\\n}\\\\n\\"
+[hh:mm:ss] TRACE: Finished to handle request
+    query: \\"{\\\\n  jwt_foo\\\\n}\\\\n\\"
+    durationMs: XXX
 \\"***** END OUTPUT CAPTURE *****"
 `;

--- a/services/tests/e2e/docker-compose.yml
+++ b/services/tests/e2e/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         {
           "jwt": {
             "http://localhost:8070": {
-              "jwkUrl": "http://oidc-server-mock/.well-known/openid-configuration/jwks",
+              "jwksUri": "http://oidc-server-mock/.well-known/openid-configuration/jwks",
               "audience": "Stitch Gateway",
               "authenticatedPaths": ["/graphql"]
             }

--- a/services/tests/helpers/get-container-logs.ts
+++ b/services/tests/helpers/get-container-logs.ts
@@ -73,6 +73,7 @@ export async function startContainerOutputCapture(container: string) {
     return result
       .substring(startCapturePosition, endCapturePosition)
       .replace(/\[\d\d:\d\d:\d\d]/g, '[hh:mm:ss]')
-      .replace(/\n.+\| /g, '\n');
+      .replace(/\n.+\| /g, '\n')
+      .replace(/\[\d\dm/g, '');
   };
 }


### PR DESCRIPTION
We use [`jwks-rsa`](https://github.com/auth0/node-jwks-rsa) module to get JWKs.
In order to keep its cache we need to keep the client object that were created.
This PR fixes previously wrong use of the module.