### PR TITLE
Add required flag to @rest directive query params

### DIFF
--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -25,9 +25,9 @@ Full parameters:
 
 ```graphql
 input KeyValue {
-    key: String!
-    value: String!
-    required: Boolean # Defaults to false
+  key: String!
+  value: String!
+  required: Boolean # Defaults to false
 }
 
 directive @rest(

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -27,6 +27,7 @@ Full parameters:
 input KeyValue {
     key: String!
     value: String!
+    required: Boolean # Defaults to false. Used with query parameters
 }
 
 directive @rest(

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -27,7 +27,7 @@ Full parameters:
 input KeyValue {
     key: String!
     value: String!
-    required: Boolean # Defaults to false. Used with query parameters
+    required: Boolean # Defaults to false
 }
 
 directive @rest(

--- a/services/src/modules/directives/rest/datasource.spec.ts
+++ b/services/src/modules/directives/rest/datasource.spec.ts
@@ -1,6 +1,7 @@
 import 'jest-fetch-mock';
 import { InMemoryLRUCache } from 'apollo-server-caching';
 import { RESTDirectiveDataSource } from './datasource';
+
 jest.mock('../../logger');
 
 const emptyContext = {
@@ -88,6 +89,69 @@ describe('REST directive data source', () => {
     expect(req.url).toBe('http://somewhere/');
   });
 
+  it('Sends request if required headers are included', async () => {
+    await ds.doRequest(
+      {
+        url: 'http://somewhere',
+        headers: [
+          { key: 'mykey', value: 'myvalue', required: true },
+          { key: 'owner', value: '{args.name}' },
+        ],
+      },
+      null,
+      { name: 'aviv' },
+      {} as any,
+      {} as any
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const req = fetchMock.mock.calls[0][0] as Request;
+    expect(req.headers.get('mykey')).toBe('myvalue');
+    expect(req.headers.get('owner')).toBe('aviv');
+  });
+
+  it('Does not send request if required headers are empty', async () => {
+    try{
+      await ds.doRequest(
+        {
+          url: 'http://somewhere',
+          headers: [
+            { key: 'mykey', value: '', required: true },
+            { key: 'owner', value: '{args.name}' },
+          ],
+        },
+        null,
+        { name: 'aviv' },
+        {} as any,
+        {} as any
+      );
+    }catch(err) {
+      expect(err.toString()).toBe("mykey header is required");
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('Sends request when header is missing the value and required is not set (default false)', async () => {
+    await ds.doRequest(
+      {
+        url: 'http://somewhere',
+        headers: [
+          { key: 'mykey', value: '' },
+          { key: 'owner', value: '{args.name}' },
+        ],
+      },
+      null,
+      { name: 'aviv' },
+      {} as any,
+      {} as any
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const req = fetchMock.mock.calls[0][0] as Request;
+    expect(req.headers.get('mykey')).toBe('');
+    expect(req.headers.get('owner')).toBe('aviv');
+  });
+
   describe('Supported http methods dispatch with the correct http method', () => {
     const methods = ['GET', 'DELETE', 'POST', 'PUT', 'PATCH'];
 
@@ -152,11 +216,30 @@ describe('REST directive data source', () => {
   });
 
   it('Does not send request if required query parameters are missing values', async () => {
+    try{
+      await ds.doRequest(
+        {
+          url: 'http://somewhere',
+          method: 'GET',
+          query: [{ key: 'field1', value: '', required: true }],
+        },
+        null,
+        {} as any,
+        {} as any,
+        {} as any
+      );
+    }catch (err) {
+      expect(err.toString()).toBe("field1 query parameter is required");
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('Properly handles boolean query parameter values', async () => {
     await ds.doRequest(
       {
         url: 'http://somewhere',
         method: 'GET',
-        query: [{ key: 'field1', value: '', required: true }],
+        query: [{ key: 'field1', value: 'false', required: true }],
       },
       null,
       {} as any,
@@ -164,6 +247,26 @@ describe('REST directive data source', () => {
       {} as any
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const req = fetchMock.mock.calls[0][0] as Request;
+    expect(req.url).toBe('http://somewhere/?field1=false');
+  });
+
+  it('Sends request when empty values are sent in the query params and required is not set (default false)', async () => {
+    await ds.doRequest(
+      {
+        url: 'http://somewhere',
+        method: 'GET',
+        query: [{ key: 'field1', value: '' }],
+      },
+      null,
+      {} as any,
+      {} as any,
+      {} as any
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const req = fetchMock.mock.calls[0][0] as Request;
+    expect(req.url).toBe('http://somewhere/');
   });
 });

--- a/services/src/modules/directives/rest/datasource.spec.ts
+++ b/services/src/modules/directives/rest/datasource.spec.ts
@@ -131,4 +131,39 @@ describe('REST directive data source', () => {
     expect(req.headers.get('Content-Type')).toBe('application/json');
     expect(await req.text()).toBe('{"name":"aviv"}');
   });
+
+  it('Sends request if required query parameters are included', async () => {
+    await ds.doRequest(
+      {
+        url: 'http://somewhere',
+        method: 'GET',
+        query: [{ key: 'field1', value: 'value1', required: true }],
+      },
+      null,
+      {} as any,
+      {} as any,
+      {} as any
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const req = fetchMock.mock.calls[0][0] as Request;
+    expect(req.url).toBe('http://somewhere/?field1=value1');
+    expect(req.method).toBe('GET');
+  });
+
+  it('Does not send request if required query parameters are missing values', async () => {
+    await ds.doRequest(
+      {
+        url: 'http://somewhere',
+        method: 'GET',
+        query: [{ key: 'field1', value: '', required: true }],
+      },
+      null,
+      {} as any,
+      {} as any,
+      {} as any
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
 });

--- a/services/src/modules/directives/rest/directive.ts
+++ b/services/src/modules/directives/rest/directive.ts
@@ -15,6 +15,7 @@ export const sdl = gql`
   input KeyValue {
     key: String!
     value: String!
+    required: Boolean
   }
 
   directive @rest(

--- a/services/src/modules/directives/rest/types.ts
+++ b/services/src/modules/directives/rest/types.ts
@@ -1,6 +1,7 @@
 export interface KeyValue {
   key: string;
   value: string;
+  required?: boolean;
 }
 
 export interface RestParams {


### PR DESCRIPTION
This PR is based on the slack discussion and recommendations [here](https://asurion-teams.slack.com/archives/CRLS8U5UM/p1605544550009400).

This is to add in a _required_ flag to the @rest query: [KeyValue], to ensure the API request is only sent if required query params were provided. With this change, we can avoid sending invalid request, and improve response times (due to not waiting on failed requests). 

- [x] All tests pass
- [x] New tests added
- [x] Documentation updated