### PR TITLE
Configurable origin for upstreams

### DIFF
--- a/docs/upstream_authentication.md
+++ b/docs/upstream_authentication.md
@@ -28,8 +28,11 @@ kind: Upstream
 metadata:
   name: organization-api
   namespace: organizations-team
-host: 'organizations.example.com'
-origin: 'http://some-real-origin'
+host: 'organizations.example.com' # Deprecated
+sourceHosts:
+  - 'organization1.example.com'
+  - 'organization2.example.com'
+destinationOrigin: 'http://some-real-origin' # Optional
 auth:
   type: ActiveDirectory
   activeDirectory:
@@ -37,10 +40,11 @@ auth:
     resource: <active directory resource id>
 ```
 
-At runtime, `host` works as a selector - with this upstream applied, stitch knows that any request going out to `organizations.example.com` needs a `Bearer` token from the specified authority, for the specified resource.
+At runtime, `sourceHosts` property works as a selector - with this upstream applied, stitch knows that any request going out to `organization1.example.com` needs a `Bearer` token from the specified authority, for the specified resource.
+The deprecated `host` property works like `sourceHosts` but it's single value and not a list.
 
-`origin` is the OPTIONAL property. If it is set its value replaces the `url` origin. It can be useful to use the same schema in different environments.
-So the `url` in schema can have some logical name of the service (it still should be valid URL) and in each environment differen `Upstream` resource can be used.
+`destinationOrigin` is the OPTIONAL property. If it is set its value replaces the `url` origin. It can be useful to use the same schema in different environments.
+So the `url` in schema can have some logical name of the service (it still should be valid URL) and in each environment different `Upstream` resource can be used.
 
 ## UpstreamClientCredentials
 

--- a/docs/upstream_authentication.md
+++ b/docs/upstream_authentication.md
@@ -19,24 +19,28 @@ Combined, they allow stitch to authenticate to upstream data sources. Their sepa
 
 ## Upstream
 
-An Upstream resource answers the question "Which outgoing requests need which kind of authentication?".
+An Upstream resource answers the question "How to modify outgoing request before sending?". It can be adding authentication or setting different origin for each environment.
 
 Example:
 
 ```yaml
 kind: Upstream
 metadata:
-    name: organization-api
-    namespace: organizations-team
+  name: organization-api
+  namespace: organizations-team
 host: 'organizations.example.com'
+origin: 'http://some-real-origin'
 auth:
-    type: ActiveDirectory
-    activeDirectory:
-        authority: <active directory authority url>
-        resource: <active directory resource id>
+  type: ActiveDirectory
+  activeDirectory:
+    authority: <active directory authority url>
+    resource: <active directory resource id>
 ```
 
 At runtime, `host` works as a selector - with this upstream applied, stitch knows that any request going out to `organizations.example.com` needs a `Bearer` token from the specified authority, for the specified resource.
+
+`origin` is the OPTIONAL property. If it is set its value replaces the `url` origin. It can be useful to use the same schema in different environments.
+So the `url` in schema can have some logical name of the service (it still should be valid URL) and in each environment differen `Upstream` resource can be used.
 
 ## UpstreamClientCredentials
 
@@ -47,13 +51,13 @@ Example:
 ```yaml
 kind: UpstreamClientCredentials
 metadata:
-    name: organization-api
-    namespace: organizations-team
+  name: organization-api
+  namespace: organizations-team
 authType: ActiveDirectory
 activeDirectory:
-    authority: <active directory authority url>
-    clientId: <active directory client id>
-    clientSecret: <active directory client secret>
+  authority: <active directory authority url>
+  clientId: <active directory client id>
+  clientSecret: <active directory client secret>
 ```
 
 When stitch detects a request needs activedirectory style authentication (specified through the `Upstream` resource), it will look for an `UpstreamClientCredentials` resource with the same `authType` and `authority`, and use the credentials given in it to fetch an access token.

--- a/services/src/modules/directives/gql.ts
+++ b/services/src/modules/directives/gql.ts
@@ -64,8 +64,8 @@ export class GqlDirective extends SchemaDirectiveVisitor {
     const operationType = operationTypeParam?.toLowerCase() ?? 'query';
     const upstream = this.context.authenticationConfig.getUpstreamByHost(url.host);
     let upstreamUrl = new URL(url);
-    if (upstream?.origin) {
-      upstreamUrl = new URL(url.replace(url.origin, upstream.origin));
+    if (upstream?.destinationOrigin) {
+      upstreamUrl = new URL(url.replace(url.origin, upstream.destinationOrigin));
     }
     const remoteSchema = this.createRemoteSchema(
       upstreamUrl.href,

--- a/services/src/modules/directives/rest/datasource.ts
+++ b/services/src/modules/directives/rest/datasource.ts
@@ -26,8 +26,8 @@ export class RESTDirectiveDataSource extends RESTDataSource<RequestContext> {
     let url = new URL(inject(params.url, parent, args, this.context, info) as string);
 
     const upstream = this.context.authenticationConfig.getUpstreamByHost(url.host);
-    if (upstream?.origin) {
-      url = new URL(url.href.replace(url.origin, upstream.origin));
+    if (upstream?.destinationOrigin) {
+      url = new URL(url.href.replace(url.origin, upstream.destinationOrigin));
     }
 
     this.addQueryParams(url.searchParams, params.query, parent, args, info);

--- a/services/src/modules/resource-repository/types.ts
+++ b/services/src/modules/resource-repository/types.ts
@@ -28,8 +28,9 @@ export interface Schema extends Resource {
 }
 
 export interface Upstream extends Resource {
-  host: string;
-  origin?: string;
+  host?: string;
+  sourceHosts?: string[];
+  destinationOrigin?: string;
   auth?: {
     type: AuthType;
     activeDirectory: {

--- a/services/src/modules/resource-repository/types.ts
+++ b/services/src/modules/resource-repository/types.ts
@@ -29,7 +29,8 @@ export interface Schema extends Resource {
 
 export interface Upstream extends Resource {
   host: string;
-  auth: {
+  origin?: string;
+  auth?: {
     type: AuthType;
     activeDirectory: {
       authority: string;

--- a/services/src/modules/upstream-authentication/get-auth-headers.ts
+++ b/services/src/modules/upstream-authentication/get-auth-headers.ts
@@ -1,23 +1,23 @@
 import { FastifyRequest } from 'fastify';
 import logger from '../logger';
-import { AuthenticationConfig } from './types';
+import { Upstream } from '../resource-repository';
+import { AuthenticationConfig } from '.';
 
 export async function getAuthHeaders(
+  upstream: Upstream,
   authConfig: AuthenticationConfig,
-  targetHost: string,
   originalRequest?: Pick<FastifyRequest, 'headers'>
 ) {
   // Try AD auth
-  const upstream = authConfig.getUpstreamByHost(targetHost);
   if (typeof upstream !== 'undefined') {
-    const credentials = authConfig.getUpstreamClientCredentialsByAuthority(upstream.auth.activeDirectory.authority);
+    const credentials = authConfig.getUpstreamClientCredentialsByAuthority(upstream.auth!.activeDirectory.authority);
     if (typeof credentials !== 'undefined') {
       try {
         const token = await authConfig.activeDirectoryAuth.getToken(
           credentials.activeDirectory.authority,
           credentials.activeDirectory.clientId,
           credentials.activeDirectory.clientSecret,
-          upstream.auth.activeDirectory.resource
+          upstream.auth!.activeDirectory.resource
         );
 
         return {

--- a/services/tests/integration/gateway/__snapshots__/gql-directive.spec.ts.snap
+++ b/services/tests/integration/gateway/__snapshots__/gql-directive.spec.ts.snap
@@ -72,3 +72,20 @@ Object {
   },
 }
 `;
+
+exports[`GQL Directive Remote GraphQL server call - Upstream Host 1`] = `
+Object {
+  "data": Object {
+    "employee": null,
+  },
+  "errors": Array [
+    [GraphQLError: Failed reaching remote gql server for introspection (url http://localhost:1111/graphql)],
+  ],
+  "extensions": undefined,
+  "http": Object {
+    "headers": Headers {
+      Symbol(map): Object {},
+    },
+  },
+}
+`;

--- a/services/tests/integration/gateway/__snapshots__/rest-directive.spec.ts.snap
+++ b/services/tests/integration/gateway/__snapshots__/rest-directive.spec.ts.snap
@@ -227,7 +227,7 @@ Object {
 }
 `;
 
-exports[`Rest directive - Upstream origin call qraphql 1`] = `
+exports[`Rest directive - Upstream destinationOrigin call qraphql 1`] = `
 Object {
   "data": Object {
     "hello": "world",

--- a/services/tests/integration/gateway/__snapshots__/rest-directive.spec.ts.snap
+++ b/services/tests/integration/gateway/__snapshots__/rest-directive.spec.ts.snap
@@ -226,3 +226,18 @@ Object {
   },
 }
 `;
+
+exports[`Rest directive - Upstream origin call qraphql 1`] = `
+Object {
+  "data": Object {
+    "hello": "world",
+  },
+  "errors": undefined,
+  "extensions": undefined,
+  "http": Object {
+    "headers": Headers {
+      Symbol(map): Object {},
+    },
+  },
+}
+`;

--- a/services/tests/integration/gateway/gql-directive.spec.ts
+++ b/services/tests/integration/gateway/gql-directive.spec.ts
@@ -79,8 +79,8 @@ const upstream: Upstream = {
     namespace: 'namespace',
     name: 'name',
   },
-  host: new URL(remoteLogicalHost).host,
-  origin: remoteHost,
+  sourceHosts: [new URL(remoteLogicalHost).host],
+  destinationOrigin: remoteHost,
 };
 
 const resourceGroup = {

--- a/services/tests/integration/gateway/rest-directive.spec.ts
+++ b/services/tests/integration/gateway/rest-directive.spec.ts
@@ -285,7 +285,7 @@ const testCases: [string, TestCase][] = [
     },
   ],
   [
-    'Upstream origin',
+    'Upstream destinationOrigin',
     {
       mock: () => nock(upstreamRealOrigin).get('/hello').reply(200, 'world'),
       schema: gql`
@@ -321,7 +321,7 @@ describe.each(testCases)('Rest directive - %s', (_, { mock, schema, query, varia
         name: 'rest-directive-upstream',
       },
       host: new URL(upstreamLogicHost).host,
-      origin: upstreamRealOrigin,
+      destinationOrigin: upstreamRealOrigin,
     };
 
     const resourceGroup = {


### PR DESCRIPTION
This PR adds ability to use the same `schema` resource in different environments by changing `upstream` resource.