### PR TITLE
Always use ?. with 'jwt' in argument injection

### DIFF
--- a/docs/arguments_injection.md
+++ b/docs/arguments_injection.md
@@ -177,7 +177,7 @@ query {
 ```graphql
 # Schema
 type Query {
-  foo: String! @localResolver(value: "{jwt.roles}") # foo field will be resolved to roles claim of the request JWT.
+  foo: String! @localResolver(value: "{jwt?.roles}") # foo field will be resolved to roles claim of the request JWT.
 }
 
 #Query

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -62,7 +62,7 @@ code: |
 args:
   aud:
     type: String!
-    default: '{jwt.aud}'
+    default: '{jwt?.aud}'
   allowedAudience:
     type: String!
 ```

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -33,7 +33,7 @@ code: |
 args:
   userRoles:
     type: [String!]
-    default: '{jwt.roles}'
+    default: '{jwt?.roles}'
 ```
 
 Explanation:
@@ -148,7 +148,7 @@ So if in type `User` there is field `phone` that should be accessible for user w
 type User {
   id: ID!
   name: String!
-  phone: String @policy(namespace: "billing", name: "adminOnly", args: { userRoles: "{jwt.roles}" })
+  phone: String @policy(namespace: "billing", name: "adminOnly", args: { userRoles: "{jwt?.roles}" })
 }
 ```
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -94,7 +94,7 @@ For example this plugin adds a base policy if one does not exist:
       namespace: 'ns',
       name: 'base',
       args: {
-        user: '{jwt.sub}',
+        user: '{jwt?.sub}',
       },
     }};
   }

--- a/docs/specs/authorization_spec.md
+++ b/docs/specs/authorization_spec.md
@@ -41,11 +41,11 @@ Spec:
   args:
     issuer:
       type: String!
-      default: "{jwt.issuer}"
+      default: "{jwt?.issuer}"
 ```
 
 The `args` are available to use on the input object.
-`jwt` is available for parameter injection in args using `issuer: "{jwt.issuer}"`
+`jwt` is available for parameter injection in args using `issuer: "{jwt?.iss}"`
 
 ### Policy that allows access only if the subject matches the provided userId argument:
 
@@ -163,7 +163,7 @@ type User {
   ID: ID!
   Picture: String @policy-some-ns-public
   Friends: [User] @policy-some-ns-abc-user
-  Email: String @policy-some-ns-my-user(userId: "{source.UserId}", sub: "{jwt.sub}")
+  Email: String @policy-some-ns-my-user(userId: "{source.UserId}", sub: "{jwt?.sub}")
   NickName: @policy-some-ns-my-user-family(userId: "{source.UserId}")
 }
 ```
@@ -297,6 +297,6 @@ Usage:
 ```gql
 type User {
   ID: ID!
-  Picture: String @policy-some-ns-has-claims(claims:["issuer", "sub"], values: ["soluto.com", "{source.UserId}"], jwtClaims: "{jwt.claims}")
+  Picture: String @policy-some-ns-has-claims(claims:["issuer", "sub"], values: ["soluto.com", "{source.UserId}"], jwtClaims: "{jwt?.claims}")
 }
 ```

--- a/services/src/modules/arguments-injection/arguments-injection.spec.ts
+++ b/services/src/modules/arguments-injection/arguments-injection.spec.ts
@@ -4,7 +4,7 @@ import { inject } from './arguments-injection';
 
 interface TestCase {
   input: unknown;
-  params: GraphQLFieldResolverParams<unknown, Pick<RequestContext, 'request' | 'exports' | 'request'>>
+  params: GraphQLFieldResolverParams<unknown, Pick<RequestContext, 'request' | 'exports' | 'request'>>;
   expected: unknown;
 }
 
@@ -62,7 +62,7 @@ const testCases: [string, TestCase][] = [
   [
     'From JWT',
     {
-      input: '{jwt.email}',
+      input: '{jwt?.email}',
       params: {
         source: null,
         args: {},


### PR DESCRIPTION
`jwt` in argument injection should be always be used with null propagation. In case the request doesn't contain `Authorizaion` header with JWT, the `jwt` object in argument evaluation context will be `null` so expression like `"{jwt.iss}"` will throw exception. In the case of exception argument is evaluation to the string so the value will be `"{jwt.iss}"` instead of `undefined`. 

So the right way to use the `jwt` object is `"{jwt?.iss}"`.