### PR TITLE
Default upstream + upstream headers

### DIFF
--- a/docs/upstream_authentication.md
+++ b/docs/upstream_authentication.md
@@ -55,11 +55,15 @@ Properties:
 
 `auth`: _(optional)_ Allows to build `Authorization` header. For example using _Client Credentials_ flow.
 
-`headers`: _(optional)_ Allows to add or replace headers in outgoing request. Argument injection mechanism is available.
+`headers`: _(optional)_ Allows to add or replace headers in outgoing request. Argument injection mechanism is available. Unlike argument injection in `@rest` directive `url`, `query` or `header` parameters or `@policy` directive `args` parameter the data sources are different. There are 3 data sources available for injection:
+
+- `incomingRequest` - the request object sent to Stitch
+- `jwt` - decoded JWT from `incomingRequest`'s `Authorization` header
+- `outgoingRequest` - the request object built by `@rest` or `@gql` directives before application of upstream
 
 ## Default Upstream
 
-There is option to set one default upstream to the whole deployment. This default upstream will be applied unless specific upstream wasn't found for the request host (TODO: `extendDefaultUpstream` property???). This can be useful to add some headers to all outgoing requests or to redirect all requests to proxy server.
+There is option to set one default upstream to the whole deployment. This default upstream will be applied unless specific upstream wasn't found for the request host. This can be useful to add some headers to all outgoing requests or to redirect all requests to proxy server.
 
 If neither upstream nor default upstream is set for the `@rest` or `@gql` directive's `url`, the incoming request's `Authorization` header will be copied to outgoing request.
 

--- a/docs/upstream_authentication.md
+++ b/docs/upstream_authentication.md
@@ -19,24 +19,58 @@ Combined, they allow stitch to authenticate to upstream data sources. Their sepa
 
 ## Upstream
 
-An Upstream resource answers the question "Which outgoing requests need which kind of authentication?".
+An Upstream resource modifies all outgoing request to particular remote host.
 
 Example:
 
 ```yaml
 kind: Upstream
 metadata:
-    name: organization-api
-    namespace: organizations-team
-host: 'organizations.example.com'
+  name: organization-api
+  namespace: organizations-team
+host: 'organizations.example.com' # deprecated
+sourceHosts:
+  - 'organizations.example.com'
+  - 'org.example.com'
+targetOrigin: https://org.dev.example.com
 auth:
-    type: ActiveDirectory
-    activeDirectory:
-        authority: <active directory authority url>
-        resource: <active directory resource id>
+  type: ActiveDirectory
+  activeDirectory:
+    authority: <active directory authority url>
+    resource: <active directory resource id>
+headers:
+  - name: some-header-name
+    value: '{incomingRequest?.headers?.["some-header-from-request"]'
 ```
 
-At runtime, `host` works as a selector - with this upstream applied, stitch knows that any request going out to `organizations.example.com` needs a `Bearer` token from the specified authority, for the specified resource.
+Properties:
+
+`host`: **Deprecated** Uses a selector for upstream. Use `sourceHosts` instead.
+
+`sourceHosts`: Uses as selector for upstream. If one of the values in list suits to url host the upstream is applied. Every value in list should be unique across all upstreams.
+
+> One (not both) of properties `host` or `sourceHosts` must be provided.
+
+`targetOrigin`: _(optional)_ Replaces the url origin.
+
+`auth`: _(optional)_ Allows to build `Authorization` header. For example using _Client Credentials_ flow.
+
+`headers`: _(optional)_ Allows to add or replace headers in outgoing request. Argument injection mechanism is available.
+
+## Default Upstream
+
+There is option to set one default upstream to the whole deployment. This default upstream will be applied unless specific upstream wasn't found for the request host (TODO: `extendDefaultUpstream` property???). This can be useful to add some headers to all outgoing requests or to redirect all requests to proxy server.
+
+If neither upstream nor default upstream is set for the `@rest` or `@gql` directive's `url`, the incoming request's `Authorization` header will be copied to outgoing request.
+
+```yaml
+targetOrigin: https://proxy-server
+headers:
+  - name: Host
+    value: '{outgoingRequest.url.host}'
+  - name: Authorization
+    value: '{incomingRequest?.headers?.["authorization"]'
+```
 
 ## UpstreamClientCredentials
 
@@ -47,13 +81,13 @@ Example:
 ```yaml
 kind: UpstreamClientCredentials
 metadata:
-    name: organization-api
-    namespace: organizations-team
+  name: organization-api
+  namespace: organizations-team
 authType: ActiveDirectory
 activeDirectory:
-    authority: <active directory authority url>
-    clientId: <active directory client id>
-    clientSecret: <active directory client secret>
+  authority: <active directory authority url>
+  clientId: <active directory client id>
+  clientSecret: <active directory client secret>
 ```
 
 When stitch detects a request needs activedirectory style authentication (specified through the `Upstream` resource), it will look for an `UpstreamClientCredentials` resource with the same `authType` and `authority`, and use the credentials given in it to fetch an access token.

--- a/services/src/modules/registry-schema/resolvers/index.ts
+++ b/services/src/modules/registry-schema/resolvers/index.ts
@@ -2,6 +2,7 @@ import { IResolvers } from 'graphql-tools';
 import GraphQLJSON, { GraphQLJSONObject } from 'graphql-type-json';
 import {
   BasePolicyInput,
+  DefaultUpstreamInput,
   PolicyInput,
   ResourceGroupInput,
   ResourceGroupMetadataInput,
@@ -34,6 +35,9 @@ const resolvers: IResolvers = {
 
     validateBasePolicy: (_, args: { input: BasePolicyInput }, context) =>
       handleUpdateResourceGroupRequest({ basePolicy: args.input }, context.activeDirectoryAuth, true),
+
+    validateDefaultUpstream: (_, args: { input: DefaultUpstreamInput }, context) =>
+      handleUpdateResourceGroupRequest({ defaultUpstream: args.input }, context.activeDirectoryAuth, true),
   },
   Mutation: {
     // Update
@@ -55,6 +59,9 @@ const resolvers: IResolvers = {
     updateBasePolicy: (_, args: { input: BasePolicyInput }, context) =>
       handleUpdateResourceGroupRequest({ basePolicy: args.input }, context.activeDirectoryAuth),
 
+    setDefaultUpstream: (_, args: { input: DefaultUpstreamInput }, context) =>
+      handleUpdateResourceGroupRequest({ defaultUpstream: args.input }, context.activeDirectoryAuth),
+
     // Deletion
     deleteResources: (_, args: { input: Partial<ResourceGroupMetadataInput> }, context) =>
       handleDeleteResourcesRequest(args.input, context.activeDirectoryAuth),
@@ -73,6 +80,9 @@ const resolvers: IResolvers = {
 
     deleteBasePolicy: (_, args: { input: boolean }, context) =>
       handleDeleteResourcesRequest({ basePolicy: args.input }, context.activeDirectoryAuth),
+
+    resetDefaultUpstream: (_, args: { input: boolean }) =>
+      handleDeleteResourcesRequest({ defaultUpstream: args.input }),
   },
 };
 

--- a/services/src/modules/registry-schema/resolvers/index.ts
+++ b/services/src/modules/registry-schema/resolvers/index.ts
@@ -81,8 +81,8 @@ const resolvers: IResolvers = {
     deleteBasePolicy: (_, args: { input: boolean }, context) =>
       handleDeleteResourcesRequest({ basePolicy: args.input }, context.activeDirectoryAuth),
 
-    resetDefaultUpstream: (_, args: { input: boolean }) =>
-      handleDeleteResourcesRequest({ defaultUpstream: args.input }),
+    resetDefaultUpstream: (_, args: { input: boolean }, context) =>
+      handleDeleteResourcesRequest({ defaultUpstream: args.input }, context.activeDirectoryAuth),
   },
 };
 

--- a/services/src/modules/registry-schema/typedefs.ts
+++ b/services/src/modules/registry-schema/typedefs.ts
@@ -99,8 +99,6 @@ export default gql`
   }
 
   input DefaultUpstreamInput {
-    host: String
-    sourceHosts: [String!]
     targetOrigin: String
     auth: AuthInput
     headers: [UpstreamHeader!]

--- a/services/src/modules/registry-schema/typedefs.ts
+++ b/services/src/modules/registry-schema/typedefs.ts
@@ -81,12 +81,18 @@ export default gql`
     resource: String!
   }
 
+  input UpstreamHeader {
+    name: String!
+    value: String!
+  }
+
   input UpstreamInput {
     metadata: ResourceMetadataInput!
     host: String
     sourceHosts: [String!]
     targetOrigin: String
     auth: AuthInput
+    headers: [UpstreamHeader!]
   }
 
   # Upstream client credentials

--- a/services/src/modules/registry-schema/typedefs.ts
+++ b/services/src/modules/registry-schema/typedefs.ts
@@ -36,6 +36,7 @@ export default gql`
     validateUpstreamClientCredentials(input: [UpstreamClientCredentialsInput!]!): Result
     validatePolicies(input: [PolicyInput!]!): Result
     validateBasePolicy(input: BasePolicyInput!): Result
+    validateDefaultUpstream(input: DefaultUpstreamInput!): Result
   }
 
   type Mutation {
@@ -45,6 +46,7 @@ export default gql`
     updateUpstreamClientCredentials(input: [UpstreamClientCredentialsInput!]!): Result
     updatePolicies(input: [PolicyInput!]!): Result
     updateBasePolicy(input: BasePolicyInput!): Result
+    setDefaultUpstream(input: DefaultUpstreamInput!): Result
 
     deleteResources(input: ResourceGroupMetadataInput!): Result
     deleteSchemas(input: [ResourceMetadataInput!]!): Result
@@ -52,6 +54,7 @@ export default gql`
     deleteUpstreamClientCredentials(input: [ResourceMetadataInput!]!): Result
     deletePolicies(input: [ResourceMetadataInput!]!): Result
     deleteBasePolicy(input: Boolean!): Result
+    resetDefaultUpstream(input: Boolean!): Result
   }
 
   # Schemas
@@ -88,6 +91,14 @@ export default gql`
 
   input UpstreamInput {
     metadata: ResourceMetadataInput!
+    host: String
+    sourceHosts: [String!]
+    targetOrigin: String
+    auth: AuthInput
+    headers: [UpstreamHeader!]
+  }
+
+  input DefaultUpstreamInput {
     host: String
     sourceHosts: [String!]
     targetOrigin: String

--- a/services/src/modules/registry-schema/types.ts
+++ b/services/src/modules/registry-schema/types.ts
@@ -44,8 +44,10 @@ interface ActiveDirectoryAuthInput {
 
 export interface UpstreamInput {
   metadata: ResourceMetadataInput;
-  host: string;
-  auth: {
+  host?: string;
+  sourceHosts?: string[];
+  targetOrigin?: string;
+  auth?: {
     type: AuthType;
     activeDirectory: ActiveDirectoryAuthInput;
   };

--- a/services/src/modules/registry-schema/types.ts
+++ b/services/src/modules/registry-schema/types.ts
@@ -49,6 +49,10 @@ export interface UpstreamInput {
     type: AuthType;
     activeDirectory: ActiveDirectoryAuthInput;
   };
+  headers?: {
+    name: string;
+    value: string;
+  }[];
 }
 
 export interface UpstreamClientCredentialsInput {

--- a/services/src/modules/registry-schema/types.ts
+++ b/services/src/modules/registry-schema/types.ts
@@ -18,7 +18,10 @@ export interface ResourceGroupMetadataInput {
   upstreamClientCredentials?: ResourceMetadataInput[];
   policies?: ResourceMetadataInput[];
   basePolicy?: boolean;
+  defaultUpstream?: boolean;
 }
+
+export type DefaultUpstreamInput = Omit<UpstreamInput, 'metadata' | 'host' | 'sourceHosts'>;
 
 export interface ResourceGroupInput {
   schemas?: SchemaInput[];
@@ -26,6 +29,7 @@ export interface ResourceGroupInput {
   upstreamClientCredentials?: UpstreamClientCredentialsInput[];
   policies?: PolicyInput[];
   basePolicy?: BasePolicyInput;
+  defaultUpstream?: DefaultUpstreamInput;
 }
 
 export interface SchemaInput {

--- a/services/src/modules/resource-repository/actions/delete.ts
+++ b/services/src/modules/resource-repository/actions/delete.ts
@@ -44,5 +44,9 @@ export default function applyResourceGroupDeletions(
     newRg.basePolicy = undefined;
   }
 
+  if (deletions.defaultUpstream) {
+    newRg.defaultUpstream = undefined;
+  }
+
   return newRg;
 }

--- a/services/src/modules/resource-repository/actions/update.ts
+++ b/services/src/modules/resource-repository/actions/update.ts
@@ -53,5 +53,9 @@ export default function applyResourceGroupUpdates(rg: ResourceGroup, update: Par
     newRg.basePolicy = update.basePolicy;
   }
 
+  if (typeof update.defaultUpstream !== 'undefined') {
+    newRg.defaultUpstream = update.defaultUpstream;
+  }
+
   return newRg;
 }

--- a/services/src/modules/resource-repository/types.ts
+++ b/services/src/modules/resource-repository/types.ts
@@ -14,6 +14,7 @@ export interface ResourceGroup {
   // policyAttachments are compiled from the Rego code in opa policies, they are not directly modified by users
   policyAttachments?: PolicyAttachments;
   basePolicy?: Policy;
+  defaultUpstream?: DefaultUpstream;
   remoteSchemas?: RemoteSchema[];
 }
 
@@ -32,6 +33,7 @@ export interface ResourceGroupMetadata {
   upstreamClientCredentials: ResourceMetadata[];
   policies: ResourceMetadata[];
   basePolicy: boolean;
+  defaultUpstream: boolean;
 }
 
 export interface Schema extends Resource {
@@ -54,6 +56,8 @@ export interface Upstream extends Resource {
     value: string;
   }[];
 }
+
+export type DefaultUpstream = Omit<Upstream, 'metadata' | 'host' | 'sourceHosts'>;
 
 export interface UpstreamClientCredentials extends Resource {
   authType: AuthType;

--- a/services/src/modules/resource-repository/types.ts
+++ b/services/src/modules/resource-repository/types.ts
@@ -49,6 +49,10 @@ export interface Upstream extends Resource {
       resource: string;
     };
   };
+  headers?: {
+    name: string;
+    value: string;
+  }[];
 }
 
 export interface UpstreamClientCredentials extends Resource {

--- a/services/src/modules/upstreams/__snapshots__/upstreams.spec.ts.snap
+++ b/services/src/modules/upstreams/__snapshots__/upstreams.spec.ts.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Upstreams Add header 1`] = `
+Object {
+  "headers": Object {
+    "Content-Type": "application/json",
+    "Host": "maps.google.com",
+    "x-api-client": "upstream-tests",
+  },
+  "method": "POST",
+  "url": "https://maps.google.com/api/v1/get-location?city=TelAviv",
+}
+`;
+
+exports[`Upstreams Add header from incoming request 1`] = `
+Object {
+  "headers": Object {
+    "Content-Type": "application/json",
+    "Host": "maps.google.com",
+    "transactionId": "1",
+  },
+  "method": "POST",
+  "url": "https://maps.google.com/api/v1/get-location?city=TelAviv",
+}
+`;
+
+exports[`Upstreams Change url 1`] = `
+Object {
+  "headers": Object {
+    "Content-Type": "application/json",
+    "Host": "maps.google.com",
+  },
+  "method": "POST",
+  "url": "https://www.facebook.com/api/v1/get-location?city=TelAviv",
+}
+`;
+
+exports[`Upstreams Custom default upstream 1`] = `
+Object {
+  "headers": Object {
+    "Content-Type": "application/json",
+    "Host": "maps.google.com",
+    "authorization": "bearer s0mth1ng",
+  },
+  "method": "POST",
+  "url": "https://maps.google.com/api/v1/get-location?city=TelAviv",
+}
+`;
+
+exports[`Upstreams Custom default upstream and upstream 1`] = `
+Object {
+  "headers": Object {
+    "Content-Type": "application/json",
+    "Host": "maps.google.com",
+    "authorization": "BEARER S0MTH1NG",
+  },
+  "method": "POST",
+  "url": "https://maps.google.com/api/v1/get-location?city=TelAviv",
+}
+`;
+
+exports[`Upstreams Default default upstream 1`] = `
+Object {
+  "headers": Object {
+    "Authorization": "Bearer S0mTh1nG",
+    "Content-Type": "application/json",
+    "Host": "maps.google.com",
+  },
+  "method": "POST",
+  "url": "https://maps.google.com/api/v1/get-location?city=TelAviv",
+}
+`;
+
+exports[`Upstreams No upstream 1`] = `
+Object {
+  "headers": Object {
+    "Content-Type": "application/json",
+    "Host": "maps.google.com",
+  },
+  "method": "POST",
+  "url": "https://maps.google.com/api/v1/get-location?city=TelAviv",
+}
+`;

--- a/services/src/modules/upstreams/authentication/get-auth-headers.ts
+++ b/services/src/modules/upstreams/authentication/get-auth-headers.ts
@@ -1,4 +1,3 @@
-import { FastifyRequest } from 'fastify';
 import logger from '../../logger';
 import { Upstream, UpstreamClientCredentials } from '../../resource-repository';
 import { ActiveDirectoryAuth } from './active-directory-auth';
@@ -6,43 +5,32 @@ import { ActiveDirectoryAuth } from './active-directory-auth';
 export async function getAuthHeaders(
   upstream: Upstream,
   upstreamClientCredentials: UpstreamClientCredentials[],
-  activeDirectoryAuth: ActiveDirectoryAuth,
-  originalRequest?: Pick<FastifyRequest, 'headers'>
+  activeDirectoryAuth: ActiveDirectoryAuth
 ) {
   // Try AD auth
   // TODO: Store upstreams in map for quick lookup
 
-  if (upstream.auth) {
-    // TODO: Store upstreamClientCredentials in map for quick lookup
-    const credentials = upstreamClientCredentials.find(
-      uc => uc.activeDirectory.authority === upstream.auth!.activeDirectory.authority
+  if (!upstream.auth) return;
+
+  // TODO: Store upstreamClientCredentials in map for quick lookup
+  const credentials = upstreamClientCredentials.find(
+    uc => uc.activeDirectory.authority === upstream.auth!.activeDirectory.authority
+  );
+  if (!credentials) return;
+
+  try {
+    const token = await activeDirectoryAuth.getToken(
+      credentials.activeDirectory.authority,
+      credentials.activeDirectory.clientId,
+      credentials.activeDirectory.clientSecret,
+      upstream.auth.activeDirectory.resource
     );
-    if (typeof credentials !== 'undefined') {
-      try {
-        const token = await activeDirectoryAuth.getToken(
-          credentials.activeDirectory.authority,
-          credentials.activeDirectory.clientId,
-          credentials.activeDirectory.clientSecret,
-          upstream.auth.activeDirectory.resource
-        );
 
-        return {
-          Authorization: `Bearer ${token}`,
-        };
-      } catch (ex) {
-        logger.error('Failed to authenticate with Active Directory', ex);
-        throw ex;
-      }
-    }
-  }
-
-  // If AD auth doesn't apply, pass along the header we got from the request
-  const incomingAuthHeader = originalRequest?.headers?.['authorization'];
-  if (incomingAuthHeader) {
     return {
-      Authorization: incomingAuthHeader as string,
+      Authorization: `Bearer ${token}`,
     };
+  } catch (ex) {
+    logger.error('Failed to authenticate with Active Directory', ex);
+    throw ex;
   }
-
-  return;
 }

--- a/services/src/modules/upstreams/index.ts
+++ b/services/src/modules/upstreams/index.ts
@@ -1,5 +1,6 @@
 import { FastifyRequest } from 'fastify';
 import * as _ from 'lodash';
+import { injectArgs } from '../arguments-injection';
 import { ResourceGroup } from '../resource-repository';
 import { ActiveDirectoryAuth, getAuthHeaders } from './authentication';
 
@@ -24,6 +25,15 @@ export async function applyUpstream(
   );
 
   if (!upstream) return requestParams;
+
+  if (upstream.headers) {
+    if (!requestParams.headers) requestParams.headers = {};
+
+    for (const header of upstream.headers) {
+      const headerValue = injectArgs(header.value, { request: originalRequest }) as string;
+      requestParams.headers[header.name] = headerValue;
+    }
+  }
 
   // Authorization headers
   const headers = await getAuthHeaders(

--- a/services/src/modules/upstreams/index.ts
+++ b/services/src/modules/upstreams/index.ts
@@ -1,7 +1,7 @@
 import { FastifyRequest } from 'fastify';
 import * as _ from 'lodash';
 import { injectArgs } from '../arguments-injection';
-import { ResourceGroup } from '../resource-repository';
+import { DefaultUpstream, ResourceGroup, Upstream } from '../resource-repository';
 import { ActiveDirectoryAuth, getAuthHeaders } from './authentication';
 
 export { ActiveDirectoryAuth };
@@ -14,18 +14,38 @@ export type RequestParams = {
   timeout?: number;
 };
 
+const defaultDefaultUpstream: DefaultUpstream = {
+  headers: [
+    {
+      name: 'Authorization',
+      value: '{request?.headers?.["authorization"]}',
+    },
+  ],
+};
+
+function toUpstream(defaultUpstream: DefaultUpstream): Upstream {
+  return {
+    ...defaultUpstream,
+    sourceHosts: [],
+    metadata: {
+      namespace: 'internal',
+      name: 'default',
+    },
+  };
+}
+
 export async function applyUpstream(
   requestParams: RequestParams,
   resourceGroup: ResourceGroup,
   activeDirectoryAuth: ActiveDirectoryAuth,
   originalRequest?: Pick<FastifyRequest, 'headers'>
 ): Promise<RequestParams> {
-  const upstream = resourceGroup.upstreams.find(
-    u => u.host === requestParams.url.host || u.sourceHosts?.includes(requestParams.url.host)
-  );
+  const upstream =
+    resourceGroup.upstreams.find(
+      u => u.host === requestParams.url.host || u.sourceHosts?.includes(requestParams.url.host)
+    ) ?? toUpstream(resourceGroup.defaultUpstream ?? defaultDefaultUpstream);
 
-  if (!upstream) return requestParams;
-
+  // Headers
   if (upstream.headers) {
     if (!requestParams.headers) requestParams.headers = {};
 
@@ -36,12 +56,7 @@ export async function applyUpstream(
   }
 
   // Authorization headers
-  const headers = await getAuthHeaders(
-    upstream,
-    resourceGroup.upstreamClientCredentials,
-    activeDirectoryAuth,
-    originalRequest
-  );
+  const headers = await getAuthHeaders(upstream, resourceGroup.upstreamClientCredentials, activeDirectoryAuth);
 
   // Replace origin
   if (upstream.targetOrigin) {

--- a/services/src/modules/upstreams/upstreams.spec.ts
+++ b/services/src/modules/upstreams/upstreams.spec.ts
@@ -1,0 +1,151 @@
+import { FastifyRequest } from 'fastify';
+import * as _ from 'lodash';
+import { ResourceMetadata, ResourceGroup } from '../resource-repository';
+import { applyUpstream, RequestParams } from '.';
+
+interface TestCase {
+  resourceGroupPart: Partial<Pick<ResourceGroup, 'upstreams' | 'defaultUpstream'>>;
+  requestParams: Partial<RequestParams>;
+  incomingRequest?: Pick<FastifyRequest, 'headers'>;
+}
+
+const metadata: ResourceMetadata = {
+  namespace: 'upstream-test',
+  name: 'upstream',
+};
+
+const testCases: [string, TestCase][] = [
+  [
+    'No upstream',
+    {
+      resourceGroupPart: {},
+      requestParams: {},
+    },
+  ],
+  [
+    'Change url',
+    {
+      resourceGroupPart: {
+        upstreams: [
+          {
+            metadata,
+            sourceHosts: ['maps.google.com'],
+            targetOrigin: 'https://www.facebook.com',
+          },
+        ],
+      },
+      requestParams: {},
+    },
+  ],
+  [
+    'Add header',
+    {
+      resourceGroupPart: {
+        upstreams: [
+          {
+            metadata,
+            sourceHosts: ['maps.google.com'],
+            headers: [{ name: 'x-api-client', value: 'upstream-tests' }],
+          },
+        ],
+      },
+      requestParams: {},
+    },
+  ],
+  [
+    'Add header from incoming request',
+    {
+      resourceGroupPart: {
+        upstreams: [
+          {
+            metadata,
+            sourceHosts: ['maps.google.com'],
+            headers: [{ name: 'transactionId', value: '{incomingRequest?.headers?.transactionId}' }],
+          },
+        ],
+      },
+      requestParams: {},
+      incomingRequest: {
+        headers: {
+          transactionId: '1',
+        },
+      },
+    },
+  ],
+  [
+    'Default default upstream',
+    {
+      resourceGroupPart: {},
+      requestParams: {},
+      incomingRequest: {
+        headers: {
+          authorization: 'Bearer S0mTh1nG',
+        },
+      },
+    },
+  ],
+  [
+    'Custom default upstream',
+    {
+      resourceGroupPart: {
+        defaultUpstream: {
+          headers: [{ name: 'authorization', value: '{incomingRequest?.headers?.authorization.toLowerCase()}' }],
+        },
+      },
+      requestParams: {},
+      incomingRequest: {
+        headers: {
+          authorization: 'Bearer S0mTh1nG',
+        },
+      },
+    },
+  ],
+  [
+    'Custom default upstream and upstream',
+    {
+      resourceGroupPart: {
+        upstreams: [
+          {
+            metadata,
+            sourceHosts: ['maps.google.com'],
+            headers: [{ name: 'authorization', value: '{incomingRequest?.headers?.authorization.toUpperCase()}' }],
+          },
+        ],
+        defaultUpstream: {
+          headers: [{ name: 'authorization', value: '{incomingRequest?.headers?.authorization.toLowerCase()}' }],
+        },
+      },
+      requestParams: {},
+      incomingRequest: {
+        headers: {
+          authorization: 'Bearer S0mTh1nG',
+        },
+      },
+    },
+  ],
+];
+
+describe('Upstreams', () => {
+  const defaultResourceGroup: ResourceGroup = {
+    schemas: [],
+    upstreams: [],
+    upstreamClientCredentials: [],
+    policies: [],
+  };
+
+  const defaultRequestParams: RequestParams = {
+    url: new URL('https://maps.google.com/api/v1/get-location?city=TelAviv'),
+    headers: {
+      ['Host']: 'maps.google.com',
+      ['Content-Type']: 'application/json',
+    },
+    method: 'POST',
+  };
+
+  test.each(testCases)('%s', async (_testCaseName, { requestParams, resourceGroupPart, incomingRequest }) => {
+    const resourceGroup = { ...defaultResourceGroup, ...resourceGroupPart };
+    const request = _.cloneDeep({ ...defaultRequestParams, ...requestParams });
+    const result = await applyUpstream(request, resourceGroup, undefined as any, incomingRequest);
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/services/tests/integration/gateway/rest-directive/__snapshots__/upstreams.spec.ts.snap
+++ b/services/tests/integration/gateway/rest-directive/__snapshots__/upstreams.spec.ts.snap
@@ -18,6 +18,42 @@ Object {
 }
 `;
 
+exports[`Rest - Upstreams Upstream with headers 1`] = `
+Object {
+  "data": Object {
+    "createFoo": Object {
+      "id": "1",
+      "name": "BAR",
+    },
+  },
+  "errors": undefined,
+  "extensions": undefined,
+  "http": Object {
+    "headers": Headers {
+      Symbol(map): Object {},
+    },
+  },
+}
+`;
+
+exports[`Rest - Upstreams Upstream with headers from request 1`] = `
+Object {
+  "data": Object {
+    "createFoo": Object {
+      "id": "1",
+      "name": "BAR",
+    },
+  },
+  "errors": undefined,
+  "extensions": undefined,
+  "http": Object {
+    "headers": Headers {
+      Symbol(map): Object {},
+    },
+  },
+}
+`;
+
 exports[`Rest - Upstreams Upstream with host and targetOrigin 1`] = `
 Object {
   "data": Object {

--- a/services/tests/integration/gateway/rest-directive/__snapshots__/upstreams.spec.ts.snap
+++ b/services/tests/integration/gateway/rest-directive/__snapshots__/upstreams.spec.ts.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Rest - Upstreams Default upstream 1`] = `
+Object {
+  "data": Object {
+    "createFoo": Object {
+      "id": "1",
+      "name": "BAR",
+    },
+  },
+  "errors": undefined,
+  "extensions": undefined,
+  "http": Object {
+    "headers": Headers {
+      Symbol(map): Object {},
+    },
+  },
+}
+`;
+
 exports[`Rest - Upstreams No upstreams 1`] = `
 Object {
   "data": Object {

--- a/services/tests/integration/gateway/rest-directive/upstreams.spec.ts
+++ b/services/tests/integration/gateway/rest-directive/upstreams.spec.ts
@@ -71,7 +71,7 @@ const testCases: [string, TestCase][] = [
           headers: [
             {
               name: 'x-api-client',
-              value: '{request?.headers?.["x-api-client"] ?? "Stitch Default"}',
+              value: '{incomingRequest?.headers?.["x-api-client"] ?? "Stitch Default"}',
             },
           ],
         },

--- a/services/tests/integration/gateway/rest-directive/upstreams.spec.ts
+++ b/services/tests/integration/gateway/rest-directive/upstreams.spec.ts
@@ -10,7 +10,7 @@ import { beforeEachDispose } from '../../before-each-dispose';
 interface TestCase {
   upstreams: Upstream[];
   virtualHost?: string;
-  mockAuth?: boolean;
+  headers?: Record<string, string>;
 }
 
 const host = 'http://virtual-host';
@@ -42,16 +42,59 @@ const testCases: [string, TestCase][] = [
       virtualHost: 'http://virtual-host',
     },
   ],
+  [
+    'Upstream with headers',
+    {
+      upstreams: [
+        {
+          metadata: { namespace: 'upstreams', name: 'upsteam-3' },
+          host: new URL(defaultRemoteServer).host,
+          headers: [
+            {
+              name: 'x-api-client',
+              value: 'Stitch',
+            },
+          ],
+        },
+      ],
+      headers: { ['x-api-client']: 'Stitch' },
+    },
+  ],
+  [
+    'Upstream with headers from request',
+    {
+      upstreams: [
+        {
+          metadata: { namespace: 'upstreams', name: 'upsteam-3' },
+          host: new URL(defaultRemoteServer).host,
+          headers: [
+            {
+              name: 'x-api-client',
+              value: '{request?.headers?.["x-api-client"] ?? "Stitch Default"}',
+            },
+          ],
+        },
+      ],
+      headers: { ['x-api-client']: 'Stitch Default' },
+    },
+  ],
 ];
 
-describe.each(testCases)('Rest - Upstreams', (testCaseName, { upstreams, virtualHost }) => {
+describe.each(testCases)('Rest - Upstreams', (testCaseName, { upstreams, virtualHost, headers }) => {
   let client: ApolloServerTestClient;
   const remoteServer = virtualHost ?? defaultRemoteServer;
 
   beforeEachDispose(async () => {
-    nock(defaultRemoteServer)
-      .post('/api/mock', b => !!b.name)
-      .reply(200, (_, b: any) => ({ id: '1', name: b.name }));
+    let postMock = nock(defaultRemoteServer).post('/api/mock', b => !!b.name);
+
+    if (headers) {
+      postMock = Object.entries(headers).reduce(
+        (pm, [headerName, headerValue]) => pm.matchHeader(headerName, headerValue),
+        postMock
+      );
+    }
+
+    postMock.reply(200, (_, b: any) => ({ id: '1', name: b.name }));
 
     const schema: Schema = {
       metadata: {

--- a/services/tests/integration/registry/__snapshots__/create-resources.spec.ts.snap
+++ b/services/tests/integration/registry/__snapshots__/create-resources.spec.ts.snap
@@ -6,7 +6,7 @@ Object {
     "headers": Array [
       Object {
         "name": "x-api-client",
-        "value": "{request?.headers?.[\\"x-api-client\\"] ?? \\"Unknown\\"}",
+        "value": "{incomingRequest?.headers?.[\\"x-api-client\\"] ?? \\"Unknown\\"}",
       },
     ],
     "targetOrigin": "http://localhost:8080",

--- a/services/tests/integration/registry/__snapshots__/create-resources.spec.ts.snap
+++ b/services/tests/integration/registry/__snapshots__/create-resources.spec.ts.snap
@@ -1,0 +1,166 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Create resource Default upstream 1`] = `
+Object {
+  "defaultUpstream": Object {
+    "headers": Array [
+      Object {
+        "name": "x-api-client",
+        "value": "{request?.headers?.[\\"x-api-client\\"] ?? \\"Unknown\\"}",
+      },
+    ],
+    "targetOrigin": "http://localhost:8080",
+  },
+  "policies": Array [],
+  "policyAttachments": Object {},
+  "schemas": Array [],
+  "upstreamClientCredentials": Array [],
+  "upstreams": Array [],
+}
+`;
+
+exports[`Create resource Upstream 1`] = `
+Object {
+  "policies": Array [],
+  "policyAttachments": Object {},
+  "schemas": Array [],
+  "upstreamClientCredentials": Array [],
+  "upstreams": Array [
+    Object {
+      "auth": Object {
+        "activeDirectory": Object {
+          "authority": "https://authority",
+          "resource": "someResource",
+        },
+        "type": "ActiveDirectory",
+      },
+      "host": "test.api",
+      "metadata": Object {
+        "name": "name",
+        "namespace": "namespace",
+      },
+    },
+  ],
+}
+`;
+
+exports[`Create resource UpstreamClientCredentials 1`] = `
+Object {
+  "policies": Array [],
+  "policyAttachments": Object {},
+  "schemas": Array [],
+  "upstreamClientCredentials": Array [
+    Object {
+      "activeDirectory": Object {
+        "authority": "https://authority",
+        "clientId": "myClientId",
+        "clientSecret": "myClientSecret",
+      },
+      "authType": "ActiveDirectory",
+      "metadata": Object {
+        "name": "name",
+        "namespace": "namespace",
+      },
+    },
+  ],
+  "upstreams": Array [],
+}
+`;
+
+exports[`Create resource creates a Schema 1`] = `
+Object {
+  "policies": Array [],
+  "policyAttachments": Object {},
+  "schemas": Array [
+    Object {
+      "metadata": Object {
+        "name": "name",
+        "namespace": "namespace",
+      },
+      "schema": "type Query { something: String! }",
+    },
+  ],
+  "upstreamClientCredentials": Array [],
+  "upstreams": Array [],
+}
+`;
+
+exports[`Create resource creates a Schema using updateResourceGroup 1`] = `
+Object {
+  "policies": Array [],
+  "policyAttachments": Object {},
+  "schemas": Array [
+    Object {
+      "metadata": Object {
+        "name": "name",
+        "namespace": "namespace",
+      },
+      "schema": "type Query { something: String! }",
+    },
+  ],
+  "upstreamClientCredentials": Array [],
+  "upstreams": Array [],
+}
+`;
+
+exports[`Create resource creates an opa type policy 1`] = `
+Object {
+  "policies": Array [
+    Object {
+      "args": Object {
+        "an": "String",
+        "another": "String!",
+      },
+      "code": "real rego code
+           with multiple
+           lines",
+      "metadata": Object {
+        "name": "name",
+        "namespace": "namespace",
+      },
+      "query": Object {
+        "gql": "some gql",
+        "variables": Object {
+          "a": "b",
+        },
+      },
+      "type": "opa",
+    },
+  ],
+  "policyAttachments": Object {},
+  "schemas": Array [],
+  "upstreamClientCredentials": Array [],
+  "upstreams": Array [],
+}
+`;
+
+exports[`Create resource creates an opa type policy using updateResourceGroup 1`] = `
+Object {
+  "policies": Array [
+    Object {
+      "args": Object {
+        "an": "String",
+        "another": "String!",
+      },
+      "code": "real rego code
+           with multiple
+           lines",
+      "metadata": Object {
+        "name": "name",
+        "namespace": "namespace",
+      },
+      "query": Object {
+        "gql": "some gql",
+        "variables": Object {
+          "a": "b",
+        },
+      },
+      "type": "opa",
+    },
+  ],
+  "policyAttachments": Object {},
+  "schemas": Array [],
+  "upstreamClientCredentials": Array [],
+  "upstreams": Array [],
+}
+`;

--- a/services/tests/integration/registry/__snapshots__/create-resources.spec.ts.snap
+++ b/services/tests/integration/registry/__snapshots__/create-resources.spec.ts.snap
@@ -108,8 +108,15 @@ Object {
   "policies": Array [
     Object {
       "args": Object {
-        "an": "String",
-        "another": "String!",
+        "an": Object {
+          "default": "{source.an}",
+          "optional": false,
+          "type": "String",
+        },
+        "another": Object {
+          "optional": false,
+          "type": "String!",
+        },
       },
       "code": "real rego code
            with multiple
@@ -139,8 +146,15 @@ Object {
   "policies": Array [
     Object {
       "args": Object {
-        "an": "String",
-        "another": "String!",
+        "an": Object {
+          "default": "{source.an}",
+          "optional": false,
+          "type": "String",
+        },
+        "another": Object {
+          "optional": false,
+          "type": "String!",
+        },
       },
       "code": "real rego code
            with multiple

--- a/services/tests/integration/registry/__snapshots__/delete-resources.spec.ts.snap
+++ b/services/tests/integration/registry/__snapshots__/delete-resources.spec.ts.snap
@@ -2,6 +2,9 @@
 
 exports[`Delete resource delete an opa type policy 1`] = `
 Object {
+  "defaultUpstream": Object {
+    "targetOrigin": "http://localhost:8080",
+  },
   "policies": Array [],
   "policyAttachments": Object {},
   "schemas": Array [
@@ -53,6 +56,9 @@ exports[`Delete resource delete an opa type policy 2`] = `Object {}`;
 
 exports[`Delete resource deletes a Schema 1`] = `
 Object {
+  "defaultUpstream": Object {
+    "targetOrigin": "http://localhost:8080",
+  },
   "policies": Array [
     Object {
       "args": Object {
@@ -116,6 +122,9 @@ Object {
 
 exports[`Delete resource deletes a Schema using deleteResources 1`] = `
 Object {
+  "defaultUpstream": Object {
+    "targetOrigin": "http://localhost:8080",
+  },
   "policies": Array [
     Object {
       "args": Object {
@@ -179,6 +188,9 @@ Object {
 
 exports[`Delete resource deletes an Upstream 1`] = `
 Object {
+  "defaultUpstream": Object {
+    "targetOrigin": "http://localhost:8080",
+  },
   "policies": Array [
     Object {
       "args": Object {
@@ -238,6 +250,9 @@ Object {
 
 exports[`Delete resource deletes an UpstreamClientCredentials 1`] = `
 Object {
+  "defaultUpstream": Object {
+    "targetOrigin": "http://localhost:8080",
+  },
   "policies": Array [
     Object {
       "args": Object {
@@ -299,6 +314,9 @@ Object {
 
 exports[`Delete resource deletes an opa type policy using deleteResources 1`] = `
 Object {
+  "defaultUpstream": Object {
+    "targetOrigin": "http://localhost:8080",
+  },
   "policies": Array [],
   "policyAttachments": Object {},
   "schemas": Array [
@@ -347,3 +365,77 @@ Object {
 `;
 
 exports[`Delete resource deletes an opa type policy using deleteResources 2`] = `Object {}`;
+
+exports[`Delete resource reset an Default Upstream 1`] = `
+Object {
+  "policies": Array [
+    Object {
+      "args": Object {
+        "an": Object {
+          "type": "String",
+        },
+        "another": Object {
+          "type": "String!",
+        },
+      },
+      "code": "real rego code
+           with multiple
+           lines",
+      "metadata": Object {
+        "name": "name",
+        "namespace": "namespace",
+      },
+      "query": Object {
+        "gql": "some another gql",
+        "variables": Object {
+          "c": "d",
+        },
+      },
+      "type": "opa",
+    },
+  ],
+  "policyAttachments": Object {},
+  "schemas": Array [
+    Object {
+      "metadata": Object {
+        "name": "name",
+        "namespace": "namespace",
+      },
+      "schema": "type Query {
+  something: String!
+}
+",
+    },
+  ],
+  "upstreamClientCredentials": Array [
+    Object {
+      "activeDirectory": Object {
+        "authority": "https://authority",
+        "clientId": "myClientId",
+        "clientSecret": "myClientSecret",
+      },
+      "authType": "ActiveDirectory",
+      "metadata": Object {
+        "name": "name",
+        "namespace": "namespace",
+      },
+    },
+  ],
+  "upstreams": Array [
+    Object {
+      "auth": Object {
+        "activeDirectory": Object {
+          "authority": "https://authority",
+          "resource": "someResource",
+        },
+        "type": "ActiveDirectory",
+      },
+      "host": "test.api",
+      "metadata": Object {
+        "name": "name",
+        "namespace": "namespace",
+      },
+    },
+  ],
+}
+`;

--- a/services/tests/integration/registry/create-resources.spec.ts
+++ b/services/tests/integration/registry/create-resources.spec.ts
@@ -46,7 +46,7 @@ const defaultUpstream: DefaultUpstream = {
   headers: [
     {
       name: 'x-api-client',
-      value: '{request?.headers?.["x-api-client"] ?? "Unknown"}',
+      value: '{incomingRequest?.headers?.["x-api-client"] ?? "Unknown"}',
     },
   ],
 };

--- a/services/tests/integration/registry/delete-resources.spec.ts
+++ b/services/tests/integration/registry/delete-resources.spec.ts
@@ -77,6 +77,7 @@ const baseResourceGroup: ResourceGroup = {
   upstreams: [upstream],
   upstreamClientCredentials: [upstreamClientCredentials],
   policies: [policy],
+  defaultUpstream: { targetOrigin: 'http://localhost:8080' },
 };
 describe('Delete resource', () => {
   let client: ApolloServerTestClient;
@@ -147,6 +148,22 @@ describe('Delete resource', () => {
 
     expect(response.errors).toBeUndefined();
     expect(response.data).toEqual({ deleteUpstreams: { success: true } });
+    expect(bucketContents.current).toMatchSnapshot();
+  });
+
+  it('reset an Default Upstream', async () => {
+    const response = await client.mutate({
+      mutation: gql`
+        mutation ResetDefaultUpstreams {
+          resetDefaultUpstream(input: true) {
+            success
+          }
+        }
+      `,
+    });
+
+    expect(response.errors).toBeUndefined();
+    expect(response.data).toEqual({ resetDefaultUpstream: { success: true } });
     expect(bucketContents.current).toMatchSnapshot();
   });
 


### PR DESCRIPTION
1) New resource type added: DefaultUpstream.
This resource works like Upstream but is applied to all outgoing requests unless specific upstream isn't defined for the particular host. 

If defaultUpstream is not set there is `fabricDefaultUpstream` that is applied. It just sets `Autorization` header from incoming request to outgoing one.

TODO: decide if `upstream` should have an option to "inherit" from the `defaultUpstream`.

2) Optional `headers` property added to `Upstream` type. If the property all items from it will be evaluated using argument injection mechanism and added to outgoing request headers. Incoming request headers and original outgoing request (as is built from the rest/gql directive) are available to be injected to headers.

For example this upstream redirects traffic though proxy server:

```graphql
type Query {
  foo: String! @rest(url: "https://foo-service/api")
}
```

```yaml
metadata:
  namespace: example
  name: upstream
sourceHosts:
  - "foo-service" 
targetOrigin: "https://proxy-server"
headers:
  - name: Authorization
    value: "{incomingRequest?.headers?.['authorization']}"
  - name: Host
    value: "{ougoingRequest.url.host}"
```
