### PR TITLE
Support custom logger configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The registry is our attempt at solving the issue of collaborating on a single gr
 - [Authentication](./docs/authentication.md)
 - [Authorization](./docs/authorization.md)
 - [Plugins](./docs/plugins.md)
+- [Logging](./docs/logging.md)
 
 ## Development
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,18 @@
+# Logging
+
+Stitch uses [`pino`](https://github.com/pinojs/pino) logger. The logger default configuration can be finded [here](../services/src/modules/logger.ts).
+
+Custom configuration can be provided using `LOGGER_CONFIGURATION` environment variable.
+
+> Note: environment variable value should be JSON-serialized object of [`pino.LoggerOptions`](https://getpino.io/#/docs/api?id=options-object) type. Properties of `function` type aren't supported.
+
+Example:
+
+```yaml
+LOGGER_CONFIGURATION: |
+  {
+    "redact": [
+      "err.request.headers.authorization"
+    ]
+  }
+```

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,6 +1,6 @@
 # Logging
 
-Stitch uses [`pino`](https://github.com/pinojs/pino) logger. The logger default configuration can be finded [here](../services/src/modules/logger.ts).
+Stitch uses [`pino`](https://github.com/pinojs/pino) logger. The logger default configuration can be found [here](../services/src/modules/logger.ts).
 
 Custom configuration can be provided using `LOGGER_CONFIGURATION` environment variable.
 

--- a/services/src/modules/config.ts
+++ b/services/src/modules/config.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as envVar from 'env-var';
-import * as pino from 'pino';
+import { LoggerOptions } from 'pino';
 import { AuthenticationConfig } from './authentication/types';
 
 const envVarExt = envVar.from(process.env, {
@@ -57,4 +57,4 @@ export const knownApolloDirectives = envVarExt
   .default(defaultKnownApolloDirectives)
   .asSet();
 
-export const loggerConfiguration = envVar.get('LOGGER_CONFIGURATION').asJsonObject() as pino.LoggerOptions;
+export const loggerConfiguration = envVar.get('LOGGER_CONFIGURATION').default({}).asJsonObject() as LoggerOptions;

--- a/services/src/modules/config.ts
+++ b/services/src/modules/config.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as envVar from 'env-var';
+import * as pino from 'pino';
 import { AuthenticationConfig } from './authentication/types';
 
 const envVarExt = envVar.from(process.env, {
@@ -55,3 +56,5 @@ export const knownApolloDirectives = envVarExt
   .get('KNOWN_APOLLO_DIRECTIVES')
   .default(defaultKnownApolloDirectives)
   .asSet();
+
+export const loggerConfiguration = envVar.get('LOGGER_CONFIGURATION').asJsonObject() as pino.LoggerOptions;

--- a/services/src/modules/logger.ts
+++ b/services/src/modules/logger.ts
@@ -1,5 +1,5 @@
 import * as pino from 'pino';
-import { logLevel, nodeEnv } from './config';
+import { logLevel, nodeEnv, loggerConfiguration } from './config';
 
 const loggerConfig: pino.LoggerOptions = {
   level: logLevel.toLowerCase(),
@@ -16,4 +16,8 @@ const devLoggerConfig: pino.LoggerOptions = {
   },
 };
 
-export default pino({ ...loggerConfig, ...(nodeEnv !== 'production' ? devLoggerConfig : {}) });
+export default pino({
+  ...loggerConfig,
+  ...(nodeEnv !== 'production' ? devLoggerConfig : {}),
+  ...loggerConfiguration,
+});

--- a/services/tests/blackbox/logger.spec.ts
+++ b/services/tests/blackbox/logger.spec.ts
@@ -1,0 +1,85 @@
+import * as fs from 'fs/promises';
+import * as nock from 'nock';
+import { print } from 'graphql';
+import { gql, GraphQLRequest } from 'apollo-server-core';
+import { FastifyInstance } from 'fastify';
+import { createServer as createGateway } from '../../src/gateway';
+import { ResourceGroup, Schema } from '../../src/modules/resource-repository';
+import { startCaptureOutput } from '../helpers/get-container-logs';
+
+describe('Logger config', () => {
+  const remoteServer = 'http://remote-server';
+  const fooId = '1';
+
+  let app: FastifyInstance;
+  let dispose: () => Promise<void>;
+
+  let remoteServerScope: nock.Scope;
+
+  beforeAll(async () => {
+    remoteServerScope = nock(remoteServer).get(`/foo/${fooId}`).replyWithError('Something went wrong');
+
+    const schema: Schema = {
+      metadata: {
+        namespace: 'blackbox',
+        name: 'default-default-upstreams',
+      },
+      schema: print(gql`
+        type Query {
+          foo(id: ID!): Foo! @rest(url: "${remoteServer}/foo/{args.id}", headers: [{key: "authorization", value: "Basic UsErPaSsWoRd"}])
+        }
+
+        type Foo {
+          id: ID!
+          baz: String!
+          bar: String!
+        }
+      `),
+    };
+
+    const resources: ResourceGroup = {
+      schemas: [schema],
+      upstreams: [],
+      upstreamClientCredentials: [],
+      policies: [],
+    };
+
+    await fs.writeFile(process.env.FS_RESOURCE_REPOSITORY_PATH!, JSON.stringify(resources));
+
+    ({ app, dispose } = await createGateway());
+  });
+
+  afterAll(async () => {
+    await dispose();
+    await fs.unlink(process.env.FS_RESOURCE_REPOSITORY_PATH!);
+  });
+
+  test('should pass authorization header from incoming request to outgoing one', async () => {
+    const endCaptureOutput = startCaptureOutput();
+
+    const payload: GraphQLRequest = {
+      query: print(gql`
+        query {
+          foo(id: "${fooId}") {
+            id
+            baz
+            bar
+          }
+        }
+      `),
+    };
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      payload,
+    });
+
+    const captureResult = await endCaptureOutput();
+    expect(captureResult).toContain('"extensions": "[Redacted]"');
+
+    expect(response.statusCode).toEqual(200);
+
+    expect(remoteServerScope.isDone()).toBeTruthy();
+  });
+});

--- a/services/tests/blackbox/setup.js
+++ b/services/tests/blackbox/setup.js
@@ -13,3 +13,5 @@ process.env.AUTHENTICATION_CONFIGURATION = JSON.stringify({
     publicPaths: ['/metrics', '/.well-known/apollo/server-health', '/graphql'],
   },
 });
+
+process.env.LOGGER_CONFIGURATION = JSON.stringify({ redact: ['errors[*].extensions'] });

--- a/services/tests/helpers/get-container-logs.ts
+++ b/services/tests/helpers/get-container-logs.ts
@@ -34,7 +34,7 @@ function capturingStdWrite(
   return true;
 }
 
-function startCaptureOutput() {
+export function startCaptureOutput() {
   const originalProcessStdoutWrite = process.stdout.write;
   const originalProcessStderrWrite = process.stderr.write;
   output = '';


### PR DESCRIPTION
Now Stitch logger can be configured via environment variable.
The configuration is `pino` logger configuration. Properties of config object that are functions aren't supported.