### PR TITLE
Fix: Gateway crashes on jwk uri not resolved

### DIFF
--- a/services/src/modules/authentication/get-secret.ts
+++ b/services/src/modules/authentication/get-secret.ts
@@ -59,17 +59,24 @@ export default async function getSecret(
     return;
   }
 
-  const { authority, jwksConfig } = issuerConfig;
-  const jwkClient = await getJwkClient(authority, jwksConfig);
+  try {
+    const { authority, jwksConfig } = issuerConfig;
+    const jwkClient = await getJwkClient(authority, jwksConfig);
 
-  jwkClient.getSigningKey(kid, (err, key) => {
-    if (err) {
-      logger.error({ err, authority, jwksUri: jwksConfig?.jwksUri }, 'Failed to get JWK for request token.');
-      // eslint-disable-next-line unicorn/no-useless-undefined
-      cb(err, undefined);
-      return;
-    }
-    logger.trace({ authority }, 'JWK found');
-    cb(null, key.getPublicKey());
-  });
+    jwkClient.getSigningKey(kid, (err, key) => {
+      if (err) {
+        logger.error({ err, authority, jwksUri: jwksConfig?.jwksUri }, 'Failed to get JWK for request token.');
+        // eslint-disable-next-line unicorn/no-useless-undefined
+        cb(err, undefined);
+        return;
+      }
+      logger.trace({ authority }, 'JWK found');
+      cb(null, key.getPublicKey());
+    });
+  } catch (err) {
+    logger.error({ err, issuerConfig }, 'Failed to get JWK config.');
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    cb(err, undefined);
+    return;
+  }
 }

--- a/services/tests/e2e/authentication/__snapshots__/verify-jwt.spec.ts.snap
+++ b/services/tests/e2e/authentication/__snapshots__/verify-jwt.spec.ts.snap
@@ -65,6 +65,45 @@ exports[`Authentication - Verify JWT Invalid JWT: gateway logs 1`] = `
 \\"***** END OUTPUT CAPTURE *****"
 `;
 
+exports[`Authentication - Verify JWT JWK uri is not resolved 1`] = `
+Object {
+  "error": "Unauthorized",
+  "message": "Unauthorized",
+  "status": 401,
+  "statusCode": 401,
+}
+`;
+
+exports[`Authentication - Verify JWT JWK uri is not resolved: gateway logs 1`] = `
+"**** START OUTPUT CAPTURE *****\\"
+[hh:mm:ss.ms] DEBUG: New authority received. Creating new JWKs client...
+    authority: \\"http://discovery-endpoint-does-not-exist\\"
+[hh:mm:ss.ms] ERROR: Failed to get JWK config.
+    err: {
+      \\"type\\": \\"Error\\",
+      \\"message\\": \\"Failed to retrieve jwksUri for http://discovery-endpoint-does-not-exist from undefined\\",
+      \\"stack\\":
+          Error: Failed to retrieve jwksUri for http://discovery-endpoint-does-not-exist from undefined
+    }
+    issuerConfig: {
+      \\"authority\\": \\"http://discovery-endpoint-does-not-exist\\",
+      \\"audience\\": \\"Stitch Gateway\\",
+      \\"description\\": \\"OpenId provider without discovery endpoint\\",
+      \\"authenticatedPaths\\": [
+        \\"/graphql\\"
+      ]
+    }
+[hh:mm:ss.ms] DEBUG: Failed to verify request JWT
+    err: {
+      \\"type\\": \\"Error\\",
+      \\"message\\": \\"Failed to retrieve jwksUri for http://discovery-endpoint-does-not-exist from undefined\\",
+      \\"stack\\":
+          Error: Failed to retrieve jwksUri for http://discovery-endpoint-does-not-exist from undefined
+    }
+    issuer: \\"http://localhost:8071\\"
+\\"***** END OUTPUT CAPTURE *****"
+`;
+
 exports[`Authentication - Verify JWT Second call with valid JWT - JWKs caching 1`] = `
 Object {
   "jwt_foo": "FOO",

--- a/services/tests/e2e/authentication/verify-jwt.spec.ts
+++ b/services/tests/e2e/authentication/verify-jwt.spec.ts
@@ -92,6 +92,19 @@ describe('Authentication - Verify JWT', () => {
     expect(logs).toMatchSnapshot('gateway logs');
   });
 
+  test('JWK uri is not resolved', async () => {
+    const accessToken = await getToken({ tokenEndpoint: 'http://localhost:8071/connect/token' });
+    gatewayClient.setHeader('Authorization', `Bearer ${accessToken}`);
+
+    const endContainerOutputCapture = await startContainerOutputCapture('gateway');
+    const result = await gatewayClient.request(query).catch(e => e.response);
+    expect(result).toMatchSnapshot();
+
+    const captureResult = await endContainerOutputCapture();
+    const logs = formatLogs(captureResult);
+    expect(logs).toMatchSnapshot('gateway logs');
+  });
+
   test('Second call with valid JWT - JWKs caching', async () => {
     const accessToken = await getToken();
     gatewayClient.setHeader('Authorization', `Bearer ${accessToken}`);

--- a/services/tests/e2e/docker-compose.yml
+++ b/services/tests/e2e/docker-compose.yml
@@ -34,6 +34,12 @@ services:
               },
               "description": "OpenId provider without discovery endpoint",
               "authenticatedPaths": ["/graphql"]
+            },
+            "http://localhost:8071": {
+              "authority": "http://discovery-endpoint-does-not-exist",
+              "audience": "Stitch Gateway",
+              "description": "OpenId provider without discovery endpoint",
+              "authenticatedPaths": ["/graphql"]
             }
           },
           "anonymous": {
@@ -85,7 +91,7 @@ services:
     image: soluto/oidc-server-mock:0.3.0
     environment:
       ASPNETCORE_ENVIRONMENT: Development
-      ASPNETCORE_URLS: http://+:8060;http://+:8070
+      ASPNETCORE_URLS: http://+:8060;http://+:8070;http://+:8071
       SERVER_OPTIONS_PATH: /config/server-options.json
       API_SCOPES_PATH: /config/api-scopes.json
       API_RESOURCES_PATH: /config/api-resources.json
@@ -96,3 +102,4 @@ services:
     ports:
       - 8060:8060
       - 8070:8070
+      - 8071:8071


### PR DESCRIPTION
This PR fixes bug that happens in `get-secret` function when discovery endpoint request fails.
Usually it's shouldn't happen because it points on wrong jwt strategy authentication configuration.