### PR TITLE
@enumResolver directive

### DIFF
--- a/services/src/modules/directives/enum-resolver.spec.ts
+++ b/services/src/modules/directives/enum-resolver.spec.ts
@@ -1,0 +1,147 @@
+import { createTestClient, ApolloServerTestClient } from 'apollo-server-testing';
+import { ApolloServerBase, gql } from 'apollo-server-core';
+import { ApolloServer, IResolvers, SchemaDirectiveVisitor } from 'apollo-server-fastify';
+import { concatAST, DocumentNode } from 'graphql';
+import GraphQLJSON, { GraphQLJSONObject } from 'graphql-type-json';
+import { sdl as localResolverSdl, LocalResolverDirective } from './local-resolver';
+import { sdl as enumResolverSdl, EnumResolverDirective, EnumValueDirective } from './enum-resolver';
+
+interface TestCase {
+  typeDefs: DocumentNode;
+  resolvers?: IResolvers;
+  query: DocumentNode;
+  variables?: Record<string, unknown>;
+  expected: unknown;
+}
+
+enum Foo {
+  Bar = 'bar',
+}
+
+const testCases: [string, TestCase][] = [
+  [
+    'Enum is return type with resolver',
+    {
+      typeDefs: gql`
+        type Query {
+          foo: Foo
+        }
+      `,
+      resolvers: {
+        Query: {
+          foo: () => Foo.Bar,
+        },
+      },
+      query: gql`
+        query {
+          foo
+        }
+      `,
+      expected: { foo: 'Bar' },
+    },
+  ],
+  [
+    'Enum is return type with @localResolver',
+    {
+      typeDefs: gql`
+        type Query {
+          foo: Foo @localResolver(value: "bar")
+        }
+      `,
+      query: gql`
+        query {
+          foo
+        }
+      `,
+      expected: { foo: 'Bar' },
+    },
+  ],
+  [
+    'Enum is query argument with resolver',
+    {
+      typeDefs: gql`
+        type Query {
+          foo(f: Foo): Boolean
+        }
+      `,
+      resolvers: {
+        Query: {
+          foo: (_, args: { f: Foo }) => args.f === Foo.Bar,
+        },
+      },
+      query: gql`
+        query {
+          foo(f: Bar)
+        }
+      `,
+      expected: { foo: true },
+    },
+  ],
+  [
+    'Enum is query argument with variable with resolver',
+    {
+      typeDefs: gql`
+        type Query {
+          foo(f: Foo): Boolean
+        }
+      `,
+      resolvers: {
+        Query: {
+          foo: (_, args: { f: Foo }) => args.f === Foo.Bar,
+        },
+      },
+      query: gql`
+        query($f: Foo) {
+          foo(f: $f)
+        }
+      `,
+      variables: {
+        f: 'Bar',
+      },
+      expected: { foo: true },
+    },
+  ],
+];
+
+const baseTypeDefs = gql`
+  scalar JSON
+  scalar JSONObject
+
+  enum Foo @enumResolver {
+    Bar @enumValue(value: "bar")
+  }
+`;
+
+const schemaDirectives: Record<string, typeof SchemaDirectiveVisitor> = {
+  localResolver: LocalResolverDirective,
+  enumResolver: EnumResolverDirective,
+  enumValue: EnumValueDirective,
+};
+
+const baseResolvers: IResolvers = {
+  JSON: GraphQLJSON,
+  JSONObject: GraphQLJSONObject,
+};
+
+describe.each(testCases)('EnumResolver Directive', (testCase, { typeDefs, query, variables, expected, resolvers }) => {
+  let client: ApolloServerTestClient;
+  let server: ApolloServerBase;
+
+  beforeAll(() => {
+    server = new ApolloServer({
+      typeDefs: concatAST([typeDefs, baseTypeDefs, localResolverSdl, enumResolverSdl]),
+      schemaDirectives,
+      resolvers: { ...baseResolvers, ...resolvers },
+    });
+    client = createTestClient(server);
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  });
+
+  test(testCase, async () => {
+    const response = await client.query({ query, variables });
+    expect(response.data).toEqual(expected);
+  });
+});

--- a/services/src/modules/directives/enum-resolver.ts
+++ b/services/src/modules/directives/enum-resolver.ts
@@ -1,0 +1,57 @@
+import { gql } from 'apollo-server-core';
+import { EnumValueNode, GraphQLEnumType, GraphQLEnumValue, ValueNode } from 'graphql';
+import { SchemaDirectiveVisitor } from 'graphql-tools';
+import { GraphQLJSONObject } from 'graphql-scalars';
+
+function parseValueNode(valueNode: ValueNode) {
+  switch (valueNode.kind) {
+    case 'BooleanValue':
+    case 'IntValue':
+    case 'FloatValue':
+    case 'StringValue':
+    case 'EnumValue':
+      return valueNode.value;
+
+    case 'ObjectValue':
+      return GraphQLJSONObject.parseLiteral(valueNode, {});
+
+    default:
+      throw new Error(`Unexpected value node type ${valueNode.kind}`);
+  }
+}
+
+export class EnumValueDirective extends SchemaDirectiveVisitor {
+  visitEnumValue(value: GraphQLEnumValue) {
+    return value;
+  }
+}
+
+export class EnumResolverDirective extends SchemaDirectiveVisitor {
+  visitEnum(type: GraphQLEnumType): GraphQLEnumType | void | null {
+    const values = type.getValues().map(enumVal => {
+      const key = enumVal.name;
+      const enumValueDirective = enumVal.astNode?.directives?.find(d => d.name.value === 'enumValue');
+      if (!enumValueDirective) {
+        throw new Error('Each ENUM_VALUE must have @enumValue directive');
+      }
+      const valNode = enumValueDirective.arguments?.find(a => a.name.value === 'value')?.value;
+      if (!valNode) {
+        throw new Error('@enumValue directive must have "value" argument');
+      }
+      const value = parseValueNode(valNode);
+      return { key, value };
+    });
+
+    type.parseValue = k => values.find(({ key }) => key === k)?.value;
+    type.serialize = v => values.find(({ value }) => value === v)?.key;
+    type.parseLiteral = keyNode => {
+      const k = (keyNode as EnumValueNode).value;
+      return values.find(({ key }) => key === k)?.value;
+    };
+  }
+}
+
+export const sdl = gql`
+  directive @enumValue(value: JSON!) on ENUM_VALUE
+  directive @enumResolver on ENUM
+`;

--- a/services/src/modules/directives/index.ts
+++ b/services/src/modules/directives/index.ts
@@ -2,6 +2,7 @@ import { concatAST } from 'graphql';
 import { SchemaDirectiveVisitor } from 'graphql-tools';
 import { sdl as stubSdl, StubDirective } from './stub';
 import { sdl as localResolverSdl, LocalResolverDirective } from './local-resolver';
+import { sdl as enumResolverSdl, EnumValueDirective, EnumResolverDirective } from './enum-resolver';
 import { sdl as restSdl, RestDirective } from './rest';
 import { sdl as gqlSdl, GqlDirective } from './gql';
 import { sdl as exportSdl, ExportDirective } from './export';
@@ -27,6 +28,8 @@ export const directiveMap: { [visitorName: string]: typeof SchemaDirectiveVisito
   policies: PoliciesDirective,
   policyQuery: PolicyQueryDirective,
   localResolver: LocalResolverDirective,
+  enumResolver: EnumResolverDirective,
+  enumValue: EnumValueDirective,
 };
 
 export const sdl = concatAST([
@@ -39,6 +42,7 @@ export const sdl = concatAST([
   policiesSdl,
   policyQuerySdl,
   localResolverSdl,
+  enumResolverSdl,
 ]);
 
 export { policyScalarResolvers, policyBaseSdl };

--- a/services/tests/blackbox/__snapshots__/enum-resolver.spec.ts.snap
+++ b/services/tests/blackbox/__snapshots__/enum-resolver.spec.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@enumResolver directive Make query 1`] = `
+Object {
+  "bar": "Bar",
+  "baz": true,
+  "taz": true,
+}
+`;

--- a/services/tests/blackbox/enum-resolver.spec.ts
+++ b/services/tests/blackbox/enum-resolver.spec.ts
@@ -1,0 +1,105 @@
+import * as fs from 'fs/promises';
+import * as nock from 'nock';
+import { HTTPInjectOptions } from 'fastify';
+import { print } from 'graphql';
+import { gql, GraphQLRequest } from 'apollo-server-core';
+import { createServer as createRegistry } from '../../src/registry';
+import { createServer as createGateway } from '../../src/gateway';
+import GraphQLErrorSerializer from '../utils/graphql-error-serializer';
+import { ResourceGroup, Schema } from '../../src/modules/resource-repository';
+import { updateSchemasMutation } from '../helpers/registry-request-builder';
+
+describe('@enumResolver directive', () => {
+  const schemaFoo: Schema = {
+    metadata: { namespace: 'requires-directive', name: 'schema-foo' },
+    schema: print(gql`
+      enum Foo @enumResolver {
+        Bar @enumValue(value: "bar")
+        Baz @enumValue(value: "baz")
+        Taz @enumValue(value: "taz")
+      }
+
+      type Query {
+        bar: Foo @localResolver(value: "bar")
+        baz(f: Foo): Boolean @localResolver(value: "{args.f === 'baz'}")
+        taz(f: Foo): Boolean @localResolver(value: "{args.f === 'taz'}")
+      }
+    `),
+  };
+
+  const registryInject = (schema: Schema): HTTPInjectOptions => ({
+    method: 'POST',
+    url: '/graphql',
+    payload: {
+      query: updateSchemasMutation,
+      variables: {
+        schema,
+      },
+    },
+  });
+
+  beforeAll(async () => {
+    expect.addSnapshotSerializer(GraphQLErrorSerializer);
+
+    const resources: ResourceGroup = {
+      schemas: [],
+      upstreams: [],
+      upstreamClientCredentials: [],
+      policies: [],
+    };
+
+    await fs.writeFile(process.env.FS_RESOURCE_REPOSITORY_PATH!, JSON.stringify(resources));
+    await fs.writeFile(process.env.FS_REGISTRY_RESOURCE_REPOSITORY_PATH!, JSON.stringify(resources));
+  });
+
+  afterAll(async () => {
+    nock.cleanAll();
+    await fs.unlink(process.env.FS_RESOURCE_REPOSITORY_PATH!);
+    await fs.unlink(process.env.FS_REGISTRY_RESOURCE_REPOSITORY_PATH!);
+  });
+
+  test('Add schemas with @enumResolver directive', async () => {
+    const registryApp = await createRegistry();
+
+    const responseFoo = await registryApp.inject(registryInject(schemaFoo));
+    expect(responseFoo.statusCode).toEqual(200);
+    expect(responseFoo.json().data.result.success).toBeTruthy();
+
+    await registryApp.close();
+
+    // For some reason without this line prom-client throws error on gateway creation.
+    // Likely it stores metrics in global variable.
+    registryApp.metrics.client.register.clear();
+  });
+
+  test('Make query', async () => {
+    await fs.stat(process.env.FS_RESOURCE_REPOSITORY_PATH!);
+    await fs.stat(process.env.FS_REGISTRY_RESOURCE_REPOSITORY_PATH!);
+
+    const payload: GraphQLRequest = {
+      query: print(gql`
+        query($taz: Foo) {
+          bar
+          baz(f: Baz)
+          taz(f: $taz)
+        }
+      `),
+      variables: {
+        taz: 'Taz',
+      },
+    };
+
+    const { app: gatewayApp, dispose } = await createGateway();
+
+    const response = await gatewayApp.inject({
+      method: 'POST',
+      url: '/graphql',
+      payload,
+    });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.json().data).toMatchSnapshot();
+
+    await dispose();
+  });
+});


### PR DESCRIPTION
`@enumResolver` and `@enumValue` directives added. This directive allows to define graphql enums like typescript enums:

```typescript
enum Foo {
  Bar = 'bar',
}
```

Usage example:

```graphql
enum Foo @enumResolver {
   Bar @enumValue(value: "bar")
}
```