### PR TITLE
Fix logging timestamp for dev environment

### DIFF
--- a/services/src/modules/logger.ts
+++ b/services/src/modules/logger.ts
@@ -9,6 +9,7 @@ const loggerConfig: pino.LoggerOptions = {
 
 const devLoggerConfig: pino.LoggerOptions = {
   level: 'trace',
+  timestamp: true,
   prettyPrint: {
     colorize: true,
     translateTime: 'HH:MM:ss.l',


### PR DESCRIPTION
`timestamp: pino.stdTimeFunctions.unixTime` and ` translateTime: 'HH:MM:ss.l'` don't work good together...