### PR TITLE
Refresh remote schema mutation

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -73,9 +73,13 @@ args:
 
 <!-- commands -->
 
-- [`stitch apply:base-policy RESOURCEPATH`](#stitch-applybase-policy-resourcepath)
-- [`stitch apply:resources RESOURCESPATH`](#stitch-applyresources-resourcespath)
-- [`stitch help [COMMAND]`](#stitch-help-command)
+- [Stitch CLI](#stitch-cli)
+  - [Resources](#resources)
+  - [Commands](#commands)
+  - [`stitch apply:base-policy RESOURCEPATH`](#stitch-applybase-policy-resourcepath)
+  - [`stitch apply:resources RESOURCESPATH`](#stitch-applyresources-resourcespath)
+  - [`stitch help [COMMAND]`](#stitch-help-command)
+  - [`stitch refresh:remote-schema REMOTESERVERURL`](#stitch-refreshremote-schema-remoteserverurl)
 
 ## `stitch apply:base-policy RESOURCEPATH`
 
@@ -97,7 +101,7 @@ EXAMPLE
          Uploaded successfully!
 ```
 
-_See code: [src/commands/apply/base-policy.ts](https://github.com/Soluto/stitch/blob/v0.0.14/src/commands/apply/base-policy.ts)_
+_See code: [src/commands/apply/base-policy.ts](https://github.com/Soluto/stitch/blob/v0.0.15/src/commands/apply/base-policy.ts)_
 
 ## `stitch apply:resources RESOURCESPATH`
 
@@ -120,7 +124,7 @@ EXAMPLE
   Uploaded successfully!
 ```
 
-_See code: [src/commands/apply/resources.ts](https://github.com/Soluto/stitch/blob/v0.0.14/src/commands/apply/resources.ts)_
+_See code: [src/commands/apply/resources.ts](https://github.com/Soluto/stitch/blob/v0.0.15/src/commands/apply/resources.ts)_
 
 ## `stitch help [COMMAND]`
 
@@ -138,5 +142,26 @@ OPTIONS
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v3.2.0/src/commands/help.ts)_
+
+## `stitch refresh:remote-schema REMOTESERVERURL`
+
+Refresh remote schema
+
+```
+USAGE
+  $ stitch refresh:remote-schema REMOTESERVERURL
+
+OPTIONS
+  --authorization-header=authorization-header  Custom authorization header
+  --registry-url=registry-url                  (required) Url of the registry
+  --timeout=timeout                            [default: 10000] Request timeout
+  --verbose                                    Verbose mode
+
+EXAMPLE
+  $ stitch refresh:remote-schema http://remote-graphql-server/graphql
+  Remote schema refreshed successfully!
+```
+
+_See code: [src/commands/refresh/remote-schema.ts](https://github.com/Soluto/stitch/blob/v0.0.15/src/commands/refresh/remote-schema.ts)_
 
 <!-- commandsstop -->

--- a/cli/oclif.manifest.json
+++ b/cli/oclif.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.14",
+  "version": "0.0.15",
   "commands": {
     "apply:base-policy": {
       "id": "apply:base-policy",
@@ -87,6 +87,45 @@
         }
       },
       "args": [{ "name": "resourcesPath", "required": true }]
+    },
+    "refresh:remote-schema": {
+      "id": "refresh:remote-schema",
+      "description": "Refresh remote schema",
+      "pluginName": "stitch-cli",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ stitch refresh:remote-schema http://remote-graphql-server/graphql\nRemote schema refreshed successfully!\n"
+      ],
+      "flags": {
+        "registry-url": {
+          "name": "registry-url",
+          "type": "option",
+          "description": "Url of the registry",
+          "required": true
+        },
+        "authorization-header": {
+          "name": "authorization-header",
+          "type": "option",
+          "description": "Custom authorization header",
+          "required": false
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "option",
+          "description": "Request timeout",
+          "required": false,
+          "default": 10000
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Verbose mode",
+          "required": false,
+          "allowNo": false
+        }
+      },
+      "args": [{ "name": "remoteServerUrl", "required": true }]
     }
   }
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stitch-cli",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "author": "Aviv Rozenboim @AvivRubys",
   "repository": "Soluto/stitch",
   "homepage": "https://github.com/Soluto/stitch",

--- a/cli/src/client/index.ts
+++ b/cli/src/client/index.ts
@@ -109,7 +109,6 @@ export async function refreshRemoteSchema(
   url: string,
   options: {
     registryUrl: string;
-    dryRun?: boolean;
     authorizationHeader?: string;
   },
   clientOptions: Partial<RequestInit>

--- a/cli/src/client/index.ts
+++ b/cli/src/client/index.ts
@@ -51,6 +51,14 @@ const ValidateBasePolicyQuery = gql`
   }
 `;
 
+const RefreshRemoteSchemaMutation = gql`
+  mutation RefreshRemoteSchemaMutation($url: String!) {
+    result: refreshRemoteSchema(url: $url) {
+      success
+    }
+  }
+`;
+
 function initClient(
   options: { registryUrl: string; dryRun?: boolean; authorizationHeader?: string },
   clientOptions: Partial<RequestInit>
@@ -95,6 +103,22 @@ export async function uploadBasePolicy(
   const query = options.dryRun ? ValidateBasePolicyQuery : UploadBasePolicyMutation;
 
   return registryClient.request<{ result: { success: boolean } }>(query, { basePolicy });
+}
+
+export async function refreshRemoteSchema(
+  url: string,
+  options: {
+    registryUrl: string;
+    dryRun?: boolean;
+    authorizationHeader?: string;
+  },
+  clientOptions: Partial<RequestInit>
+) {
+  const registryClient = initClient(options, clientOptions);
+
+  const query = RefreshRemoteSchemaMutation;
+
+  return registryClient.request<{ result: { success: boolean } }>(query, { url });
 }
 
 export * from './types';

--- a/cli/src/commands/refresh/remote-schema.ts
+++ b/cli/src/commands/refresh/remote-schema.ts
@@ -1,0 +1,64 @@
+import { Command, flags } from '@oclif/command';
+import { refreshRemoteSchema } from '../../client';
+import getEnvInfo from '../../utils/get-env-info';
+
+export default class ApplyResources extends Command {
+  static description = 'Refresh remote schema';
+
+  static examples = [
+    `$ stitch refresh:remote-schema http://remote-graphql-server/graphql
+Remote schema refreshed successfully!
+`,
+  ];
+
+  static flags = {
+    'registry-url': flags.string({ required: true, env: 'STITCH_REGISTRY_URL', description: 'Url of the registry' }),
+    'authorization-header': flags.string({ required: false, description: 'Custom authorization header' }),
+    timeout: flags.integer({ required: false, default: 10000, description: 'Request timeout' }),
+    verbose: flags.boolean({ required: false, default: false, description: 'Verbose mode' }),
+  };
+
+  static args = [{ name: 'remoteServerUrl', required: true }];
+
+  private verboseMode = false;
+
+  async run() {
+    const { args, flags } = this.parse(ApplyResources);
+    this.verboseMode = flags['verbose'];
+
+    try {
+      this.log(`Refreshing remote schema...`);
+      const {
+        result: { success },
+      } = await refreshRemoteSchema(
+        args.remoteServerUrl,
+        {
+          registryUrl: flags['registry-url'],
+          authorizationHeader: flags['authorization-header'],
+        },
+        {
+          timeout: flags.timeout,
+        }
+      );
+
+      if (success) {
+        this.log(`Remote schema from ${args.remoteServerUrl} was refreshed successfully.`);
+      } else {
+        throw new Error('Something went wrong');
+      }
+    } catch (e) {
+      this.error(
+        `Refresh remote schema failed. ${e}
+
+          ${getEnvInfo(this.config, 'refresh:remote-schema')}`,
+        { ...e, exit: true }
+      );
+    }
+  }
+
+  async trace(message?: string, ...args: any[]) {
+    if (this.verboseMode) {
+      this.log(message, ...args);
+    }
+  }
+}

--- a/cli/tests/refresh-remote-schema.spec.ts
+++ b/cli/tests/refresh-remote-schema.spec.ts
@@ -1,0 +1,40 @@
+/* eslint-disable promise/valid-params */
+/* eslint-disable promise/catch-or-return */
+import { expect, test } from '@oclif/test';
+
+describe('Refresh remote schema', () => {
+  test
+    .nock('http://registry', api =>
+      api.post('/graphql').reply(200, {
+        data: {
+          result: {
+            success: true,
+          },
+        },
+      })
+    )
+    .stdout()
+    .command([
+      'refresh:remote-schema',
+      '--registry-url=http://registry/graphql',
+      'http://remote-graphql-server/graphql',
+    ])
+    .it('Verify', ctx => {
+      expect(ctx.stdout).to.contain('was refreshed successfully');
+    });
+
+  test
+    .nock('http://registry', api => api.post('/graphql').delay(100).reply(200))
+    .stdout()
+    .stderr()
+    .command([
+      'refresh:remote-schema',
+      '--registry-url=http://registry/graphql',
+      '--timeout=50',
+      'http://remote-graphql-server/graphql',
+    ])
+    .catch((e: Error) => expect(e.message).contains('network timeout at: http://registry/graphql'), {
+      raiseIfNotThrown: true,
+    })
+    .it('Timeout', () => {});
+});

--- a/services/src/modules/directives/gql/introspection.ts
+++ b/services/src/modules/directives/gql/introspection.ts
@@ -68,7 +68,7 @@ export async function updateRemoteGqlSchemas(resourceGroup: ResourceGroup, conte
   _.remove(resourceGroup.remoteSchemas, rs => unusedRemoteSchemas.has(rs.url));
 }
 
-async function fetchRemoteGqlSchema(url: string, resourceGroup: ResourceGroup, context: RegistryRequestContext) {
+export async function fetchRemoteGqlSchema(url: string, resourceGroup: ResourceGroup, context: RegistryRequestContext) {
   try {
     const link = ApolloLink.from([
       new RetryLink({

--- a/services/src/modules/registry-schema/resolvers/index.ts
+++ b/services/src/modules/registry-schema/resolvers/index.ts
@@ -17,6 +17,7 @@ import { getPlugins } from '../../plugins';
 import handleUpdateResourceGroupRequest from './update-resource-group';
 import handleDeleteResourcesRequest from './delete-resources';
 import { getRemoteSchema, getRemoteSchemas, getResource, getResourcesByType } from './get-resources';
+import refreshRemoteSchema from './refresh-remote-schema';
 
 const resolvers: IResolvers = {
   JSON: GraphQLJSON,
@@ -115,6 +116,8 @@ const resolvers: IResolvers = {
 
     resetDefaultUpstream: (_, args: { input: boolean }, context) =>
       handleDeleteResourcesRequest({ defaultUpstream: args.input }, context),
+
+    refreshRemoteSchema: (_, args: { url: string }, context) => refreshRemoteSchema(args.url, context),
   },
 };
 

--- a/services/src/modules/registry-schema/resolvers/refresh-remote-schema.ts
+++ b/services/src/modules/registry-schema/resolvers/refresh-remote-schema.ts
@@ -1,0 +1,45 @@
+import pLimit from 'p-limit';
+import * as _ from 'lodash';
+import { GraphQLError } from 'graphql';
+import logger from '../../logger';
+import { fetchRemoteGqlSchema } from '../../directives/gql/introspection';
+import getResourceRepository from '../repository';
+import { RegistryRequestContext } from '..';
+
+const singleton = pLimit(1);
+
+export default async function (url: string, context: RegistryRequestContext) {
+  const registryResourceRepository = getResourceRepository();
+  return singleton(async () => {
+    logger.info(`Proceeding remote schema refresh request...`);
+    try {
+      logger.trace('Fetching latest resource group...');
+      const { resourceGroup: registryRg } = await registryResourceRepository.fetchLatest();
+
+      if (!registryRg.remoteSchemas) {
+        throw new Error(`Unknown url: ${url}`);
+      }
+      const index = _.findIndex(registryRg.remoteSchemas, { url });
+      if (index < 0) {
+        throw new Error(`Unknown url: ${url}`);
+      }
+      const schema = await fetchRemoteGqlSchema(url, registryRg, context);
+      registryRg.remoteSchemas.splice(index, 1, { url, schema });
+
+      const gatewayResourceRepository = getResourceRepository(false);
+      const { resourceGroup: gatewayRg } = await gatewayResourceRepository.fetchLatest();
+      gatewayRg.remoteSchemas = registryRg.remoteSchemas;
+
+      logger.trace('Saving resource group...');
+      await Promise.all([
+        registryResourceRepository.update(registryRg, { registry: true }),
+        registryResourceRepository.update(gatewayRg),
+      ]);
+    } catch (err) {
+      const message = `Remote schema refresh request failed: ${err}`;
+      logger.error({ err }, message);
+      throw new GraphQLError(message);
+    }
+    return { success: true };
+  });
+}

--- a/services/src/modules/registry-schema/typedefs.ts
+++ b/services/src/modules/registry-schema/typedefs.ts
@@ -145,6 +145,8 @@ export default gql`
     deletePolicies(input: [ResourceMetadataInput!]!): Result
     deleteBasePolicy(input: Boolean!): Result
     resetDefaultUpstream(input: Boolean!): Result
+
+    refreshRemoteSchema(url: String!): Result
   }
 
   # Schemas

--- a/services/tests/blackbox/__snapshots__/remote-schemas.spec.ts.snap
+++ b/services/tests/blackbox/__snapshots__/remote-schemas.spec.ts.snap
@@ -8,6 +8,30 @@ Object {
 }
 `;
 
+exports[`Remote Schemas Add schema with @gql directive: gateway resource group 1`] = `
+Array [
+  Object {
+    "schema": "type Query {
+  foo: String
+}
+",
+    "url": "http://remote-server/graphql",
+  },
+]
+`;
+
+exports[`Remote Schemas Add schema with @gql directive: registry resource group 1`] = `
+Array [
+  Object {
+    "schema": "type Query {
+  foo: String
+}
+",
+    "url": "http://remote-server/graphql",
+  },
+]
+`;
+
 exports[`Remote Schemas Delete the schema with @gql directive 1`] = `
 Object {
   "deleteSchemas": Object {
@@ -32,7 +56,7 @@ exports[`Remote Schemas Query resource group after deletion: remote schema 1`] =
 Object {
   "remoteSchema": Object {
     "schema": "type Query {
-  foo: String
+  foo: Int
 }
 ",
     "url": "http://remote-server/graphql",
@@ -45,12 +69,24 @@ Object {
   "remoteSchemas": Array [
     Object {
       "schema": "type Query {
-  foo: String
+  foo: Int
 }
 ",
       "url": "http://remote-server/graphql",
     },
   ],
+}
+`;
+
+exports[`Remote Schemas Query resource group again: remote schema 1`] = `
+Object {
+  "remoteSchema": Object {
+    "schema": "type Query {
+  foo: Int
+}
+",
+    "url": "http://remote-server/graphql",
+  },
 }
 `;
 
@@ -77,5 +113,69 @@ Object {
       "url": "http://remote-server/graphql",
     },
   ],
+}
+`;
+
+exports[`Remote Schemas Refresh remote schema 1`] = `
+Object {
+  "refreshRemoteSchema": Object {
+    "success": true,
+  },
+}
+`;
+
+exports[`Remote Schemas Refresh remote schema: gateway resource group 1`] = `
+Array [
+  Object {
+    "schema": "type Query {
+  foo: Int
+}
+",
+    "url": "http://remote-server/graphql",
+  },
+]
+`;
+
+exports[`Remote Schemas Refresh remote schema: registry resource group 1`] = `
+Array [
+  Object {
+    "schema": "type Query {
+  foo: Int
+}
+",
+    "url": "http://remote-server/graphql",
+  },
+]
+`;
+
+exports[`Remote Schemas Try to refresh remote schema for non-exiting url 1`] = `
+{
+  "errors": [
+    {
+      "message": "Remote schema refresh request failed: Error: Unknown url: http://does-not-exist",
+      "exception": {
+        "code": "INTERNAL_SERVER_ERROR"
+      }
+    }
+  ],
+  "data": {
+    "refreshRemoteSchema": null
+  }
+}
+`;
+
+exports[`Remote Schemas Try to refresh remote schema when there is no remote schemas at all 1`] = `
+{
+  "errors": [
+    {
+      "message": "Remote schema refresh request failed: Error: Unknown url: http://remote-server/graphql",
+      "exception": {
+        "code": "INTERNAL_SERVER_ERROR"
+      }
+    }
+  ],
+  "data": {
+    "refreshRemoteSchema": null
+  }
 }
 `;

--- a/services/tests/blackbox/remote-schemas.spec.ts
+++ b/services/tests/blackbox/remote-schemas.spec.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs/promises';
 import * as nock from 'nock';
+import * as _ from 'lodash';
 import { FastifyInstance } from 'fastify';
 import { graphqlSync, print } from 'graphql';
 import { makeExecutableSchema } from 'graphql-tools';
@@ -50,32 +51,47 @@ describe('Remote Schemas', () => {
     },
   };
 
+  const refreshRemoteSchemaPayload: GraphQLRequest = {
+    query: print(gql`
+      mutation($url: String!) {
+        refreshRemoteSchema(url: $url) {
+          success
+        }
+      }
+    `),
+    variables: {
+      url: `${remoteServer}/graphql`,
+    },
+  };
+
+  const remoteSchema = makeExecutableSchema({
+    typeDefs: gql`
+      type Query {
+        foo: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        foo: () => 'FOO',
+      },
+    },
+  });
+
+  const newRemoteSchema = makeExecutableSchema({
+    typeDefs: gql`
+      type Query {
+        foo: Int
+      }
+    `,
+    resolvers: {
+      Query: {
+        foo: () => 42,
+      },
+    },
+  });
+
   beforeAll(async () => {
     expect.addSnapshotSerializer(GraphQLErrorSerializer);
-
-    const remoteSchema = makeExecutableSchema({
-      typeDefs: gql`
-        type Query {
-          foo: String
-        }
-      `,
-      resolvers: {
-        Query: {
-          foo: () => 'FOO',
-        },
-      },
-    });
-
-    nock(remoteServer)
-      .post('/graphql')
-      .reply(200, (_, body: any) =>
-        graphqlSync({
-          schema: remoteSchema,
-          source: body.query,
-          variableValues: body.variables,
-          operationName: body.operationName,
-        })
-      );
 
     const resources: ResourceGroup = {
       schemas: [],
@@ -117,7 +133,29 @@ describe('Remote Schemas', () => {
     expect(response2.json().data).toMatchSnapshot('remote schema');
   });
 
+  test('Try to refresh remote schema when there is no remote schemas at all', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      payload: refreshRemoteSchemaPayload,
+    });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.json()).toMatchSnapshot();
+  });
+
   test('Add schema with @gql directive', async () => {
+    const scope = nock(remoteServer)
+      .post('/graphql')
+      .reply(200, (_, body: any) =>
+        graphqlSync({
+          schema: remoteSchema,
+          source: body.query,
+          variableValues: body.variables,
+          operationName: body.operationName,
+        })
+      );
+
     const payload: GraphQLRequest = {
       query: print(gql`
         mutation UpdateSchemas($input: [SchemaInput!]!) {
@@ -137,8 +175,17 @@ describe('Remote Schemas', () => {
       payload,
     });
 
+    expect(scope.isDone()).toBeTruthy();
     expect(response.statusCode).toEqual(200);
     expect(response.json().data).toMatchSnapshot();
+
+    const registryRGStr = await fs.readFile(process.env.FS_RESOURCE_REPOSITORY_PATH!, { encoding: 'utf8' });
+    const registryRG: ResourceGroup = JSON.parse(registryRGStr);
+    expect(registryRG.remoteSchemas).toMatchSnapshot('registry resource group');
+
+    const gatewayRGStr = await fs.readFile(process.env.FS_REGISTRY_RESOURCE_REPOSITORY_PATH!, { encoding: 'utf8' });
+    const gatewayRG: ResourceGroup = JSON.parse(gatewayRGStr);
+    expect(gatewayRG.remoteSchemas).toMatchSnapshot('gateway resource group');
   });
 
   test('Query resource group', async () => {
@@ -159,6 +206,64 @@ describe('Remote Schemas', () => {
 
     expect(response2.statusCode).toEqual(200);
     expect(response2.json().data).toMatchSnapshot('remote schema');
+  });
+
+  test('Try to refresh remote schema for non-exiting url', async () => {
+    const refreshNonExistingRemoteSchemaPayload = _.cloneDeep(refreshRemoteSchemaPayload);
+    _.merge(refreshNonExistingRemoteSchemaPayload, {
+      variables: { url: 'http://does-not-exist' },
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      payload: refreshNonExistingRemoteSchemaPayload,
+    });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.json()).toMatchSnapshot();
+  });
+
+  test('Refresh remote schema', async () => {
+    const scope = nock(remoteServer)
+      .post('/graphql')
+      .reply(200, (_, body: any) =>
+        graphqlSync({
+          schema: newRemoteSchema,
+          source: body.query,
+          variableValues: body.variables,
+          operationName: body.operationName,
+        })
+      );
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      payload: refreshRemoteSchemaPayload,
+    });
+
+    expect(scope.isDone()).toBeTruthy();
+    expect(response.statusCode).toEqual(200);
+    expect(response.json().data).toMatchSnapshot();
+
+    const registryRGStr = await fs.readFile(process.env.FS_RESOURCE_REPOSITORY_PATH!, { encoding: 'utf8' });
+    const registryRG: ResourceGroup = JSON.parse(registryRGStr);
+    expect(registryRG.remoteSchemas).toMatchSnapshot('registry resource group');
+
+    const gatewayRGStr = await fs.readFile(process.env.FS_REGISTRY_RESOURCE_REPOSITORY_PATH!, { encoding: 'utf8' });
+    const gatewayRG: ResourceGroup = JSON.parse(gatewayRGStr);
+    expect(gatewayRG.remoteSchemas).toMatchSnapshot('gateway resource group');
+  });
+
+  test('Query resource group again', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      payload: remoteSchemaPayload,
+    });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.json().data).toMatchSnapshot('remote schema');
   });
 
   test('Delete the schema with @gql directive', async () => {


### PR DESCRIPTION
### Why
On uploading schema resources with gql directive Stitch registry makes introspection query and stores the result in resource group.
Remote service schema may change without any changes in Stitch resources.

## What
We need to refresh remote schema on deployment of new version of remote graphql service.

## How
Add `refreshRemoteSchema` mutation to Stitch registry and `refresh:remote-schema` command to stitch-cli. The cli command should be part of the remote service CI/CD pipeline.
