### PR TITLE
E2E: add tests for rego functions + Small policy refactor

### DIFF
--- a/services/src/modules/directives/index.ts
+++ b/services/src/modules/directives/index.ts
@@ -11,6 +11,7 @@ import {
   policyBaseSdl,
   policySdl,
   policiesSdl,
+  policyFieldSdl,
   policyQuerySdl,
   PolicyDirective,
   PoliciesDirective,
@@ -45,4 +46,4 @@ export const sdl = concatAST([
   enumResolverSdl,
 ]);
 
-export { policyScalarResolvers, policyBaseSdl };
+export { policyScalarResolvers, policyBaseSdl, policyFieldSdl };

--- a/services/src/modules/directives/policy/index.ts
+++ b/services/src/modules/directives/policy/index.ts
@@ -4,9 +4,11 @@ import { sdl as policySdl, PolicyDirective } from './policy';
 import { sdl as policiesSdl, PoliciesDirective, resolvers as policyScalarResolvers } from './policies';
 import { sdl as policyQuerySdl, PolicyQueryDirective } from './policy-query';
 import PolicyExecutor from './policy-executor';
+import { buildPolicyQueryTypeDef } from './policy-query-helper';
 import { Policy, LoadedPolicy } from './types';
 
 export {
+  buildPolicyQueryTypeDef,
   PolicyExecutor,
   policySdl,
   policiesSdl,
@@ -31,5 +33,11 @@ export const policyBaseSdl = gql`
 
   type Policy {
     default: PolicyResult!
+  }
+`;
+
+export const policyFieldSdl = gql`
+  type Query {
+    policy: Policy! @localResolver(value: { default: { allow: true } })
   }
 `;

--- a/services/tests/e2e/basic/__snapshots__/rego-functions.spec.ts.snap
+++ b/services/tests/e2e/basic/__snapshots__/rego-functions.spec.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Rego Functions count 1`] = `
+Object {
+  "policy": Object {
+    "e2e_rego_functions___count": Object {
+      "allow": true,
+    },
+  },
+}
+`;

--- a/services/tests/e2e/basic/rego-functions.spec.ts
+++ b/services/tests/e2e/basic/rego-functions.spec.ts
@@ -1,0 +1,83 @@
+import { print } from 'graphql';
+import { gql } from 'apollo-server-core';
+import { GraphQLClient } from 'graphql-request';
+import { PolicyArgsDefinitions, PolicyDefinition, PolicyType } from '../../../src/modules/resource-repository';
+import GraphQLErrorSerializer from '../../utils/graphql-error-serializer';
+import { sleep } from '../../helpers/utility';
+import { RegistryMutationResponse, updatePoliciesMutation } from '../../helpers/registry-request-builder';
+import { getToken } from '../../helpers/get-token';
+
+interface TestCase {
+  code: string;
+  args?: PolicyArgsDefinitions;
+  argsLiteral?: string;
+}
+
+const gatewayClient = new GraphQLClient('http://localhost:8080/graphql');
+const registryClient = new GraphQLClient('http://localhost:8090/graphql');
+
+const testCases: [string, TestCase][] = [
+  [
+    'count',
+    {
+      code: `
+        default allow = false
+        allow {
+          count(input.args.roles) > 0
+        }
+      `,
+      args: {
+        roles: {
+          type: '[String!]!',
+        },
+      },
+      argsLiteral: '(roles: ["admin"])',
+    },
+  ],
+];
+
+describe('Rego Functions', () => {
+  const namespace = 'e2e_rego_functions';
+
+  beforeAll(async () => {
+    expect.addSnapshotSerializer(GraphQLErrorSerializer);
+
+    const accessToken = await getToken();
+    gatewayClient.setHeader('Authorization', `Bearer ${accessToken}`);
+  });
+
+  test('Setup policies', async () => {
+    const policies: PolicyDefinition[] = testCases.map(([name, { code, args }]) => ({
+      metadata: {
+        namespace,
+        name,
+      },
+      type: PolicyType.opa,
+      code,
+      args,
+    }));
+
+    const policiesResponse = await registryClient.request<RegistryMutationResponse>(updatePoliciesMutation, {
+      policies,
+    });
+    expect(policiesResponse.result.success).toBeTruthy();
+
+    // Wait for gateway to update
+    await sleep(Number(process.env.WAIT_FOR_REFRESH_ON_GATEWAY) | 1500);
+  });
+
+  test.each(testCases)('%s', async (name, { argsLiteral = '' }) => {
+    const query = print(gql`
+      query CheckPolicy {
+        policy {
+          ${namespace}___${name}${argsLiteral} {
+            allow
+          }
+        }
+      }
+    `);
+
+    const response = await gatewayClient.request(query);
+    expect(response).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
1. Following OPA version upgrade this PR adds E2E regression tests for some opa functions.
2. Some policy specific code was moved from `graphql-service.ts` to `policy` directive folder 