### PR TITLE
Extend playground config support

### DIFF
--- a/services/src/modules/config.ts
+++ b/services/src/modules/config.ts
@@ -25,7 +25,7 @@ export const resourceUpdateInterval = envVarExt.get('RESOURCE_UPDATE_INTERVAL').
 
 // GraphQL configuration
 export const enableGraphQLTracing = envVarExt.get('GRAPHQL_TRACING').default('true').asBool();
-export const enableGraphQLPlayground = envVarExt.get('GRAPHQL_PLAYGROUND').default('true').asBoolStrict();
+export const enableGraphQLPlayground = envVarExt.get('GRAPHQL_PLAYGROUND').default('true').asJsonObject();
 export const enableGraphQLIntrospection = envVarExt.get('GRAPHQL_INTROSPECTION').default('true').asBoolStrict();
 
 // Policies

--- a/services/src/modules/config.ts
+++ b/services/src/modules/config.ts
@@ -3,6 +3,7 @@ import * as envVar from 'env-var';
 import { LoggerOptions } from 'pino';
 import { AuthenticationConfig } from './authentication/types';
 import { CorsConfiguration } from './cors';
+import { PlaygroundConfig } from 'apollo-server-core';
 
 const envVarExt = envVar.from(process.env, {
   asSet: (value: string) => new Set(value.split(',')),
@@ -25,7 +26,7 @@ export const resourceUpdateInterval = envVarExt.get('RESOURCE_UPDATE_INTERVAL').
 
 // GraphQL configuration
 export const enableGraphQLTracing = envVarExt.get('GRAPHQL_TRACING').default('true').asBool();
-export const enableGraphQLPlayground = envVarExt.get('GRAPHQL_PLAYGROUND').default('true').asJsonObject();
+export const enableGraphQLPlayground = envVarExt.get('GRAPHQL_PLAYGROUND').default('true').asJsonObject() as PlaygroundConfig;
 export const enableGraphQLIntrospection = envVarExt.get('GRAPHQL_INTROSPECTION').default('true').asBoolStrict();
 
 // Policies


### PR DESCRIPTION
This change should allow for a more extensive configurable playground. e.g.                 
```
GRAPHQL_PLAYGROUND: | 
                    {
                        "settings": {
                            "request.credentials": "same-origin"
                        }
                     }
```
                     
It would be a breaking change to whoever is adding false to the playground through this syntax 
`GRAPHQL_PLAYGROUND: '"false"'`, which would evaluate to truthy after the change.

To provide a false value it would need to be like this `GRAPHQL_PLAYGROUND: "false"`(single or double quoted)
