### PR TITLE
Fix JWK verification bug

### DIFF
--- a/services/src/modules/authentication/get-secret.ts
+++ b/services/src/modules/authentication/get-secret.ts
@@ -64,10 +64,10 @@ export default async function getSecret(
         logger.error({ err, authority, jwksUri: jwksConfig?.jwksUri }, 'Failed to get JWK for request token.');
         // eslint-disable-next-line unicorn/no-useless-undefined
         cb(err, undefined);
-        return;
+      } else {
+        logger.debug({ authority }, 'JWK found');
+        cb(null, key.getPublicKey());
       }
-      logger.debug({ authority }, 'JWK found');
-      cb(null, key.getPublicKey());
     });
   } catch (err) {
     logger.error({ err, issuerConfig }, 'Failed to get JWK config.');


### PR DESCRIPTION
There are two kid. The removal of the return allows this function to check for the second kid. This change has been tested, otherwise, it fails at checking the first kid for us-east-2 and returns wrongly 401 without checking the second kid.