### PR TITLE
introspection query policy

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -73,14 +73,11 @@ args:
 
 <!-- commands -->
 
-- [Stitch CLI](#stitch-cli)
-  - [Resources](#resources)
-  - [Commands](#commands)
-  - [`stitch apply:base-policy RESOURCEPATH`](#stitch-applybase-policy-resourcepath)
-  - [`stitch apply:introspection-query-policy RESOURCEPATH`](#stitch-applyintrospection-query-policy-resourcepath)
-  - [`stitch apply:resources RESOURCESPATH`](#stitch-applyresources-resourcespath)
-  - [`stitch help [COMMAND]`](#stitch-help-command)
-  - [`stitch refresh:remote-schema REMOTESERVERURL`](#stitch-refreshremote-schema-remoteserverurl)
+- [`stitch apply:base-policy RESOURCEPATH`](#stitch-applybase-policy-resourcepath)
+- [`stitch apply:introspection-query-policy RESOURCEPATH`](#stitch-applyintrospection-query-policy-resourcepath)
+- [`stitch apply:resources RESOURCESPATH`](#stitch-applyresources-resourcespath)
+- [`stitch help [COMMAND]`](#stitch-help-command)
+- [`stitch refresh:remote-schema REMOTESERVERURL`](#stitch-refreshremote-schema-remoteserverurl)
 
 ## `stitch apply:base-policy RESOURCEPATH`
 
@@ -102,7 +99,7 @@ EXAMPLE
          Uploaded successfully!
 ```
 
-_See code: [src/commands/apply/base-policy.ts](https://github.com/Soluto/stitch/blob/v0.0.15/src/commands/apply/base-policy.ts)_
+_See code: [src/commands/apply/base-policy.ts](https://github.com/Soluto/stitch/blob/v0.0.17/src/commands/apply/base-policy.ts)_
 
 ## `stitch apply:introspection-query-policy RESOURCEPATH`
 
@@ -124,7 +121,7 @@ EXAMPLE
          Uploaded successfully!
 ```
 
-_See code: [src/commands/apply/introspection-query-policy.ts](https://github.com/Soluto/stitch/blob/v0.0.15/src/commands/apply/introspection-query-policy.ts)_
+_See code: [src/commands/apply/introspection-query-policy.ts](https://github.com/Soluto/stitch/blob/v0.0.17/src/commands/apply/introspection-query-policy.ts)_
 
 ## `stitch apply:resources RESOURCESPATH`
 
@@ -147,7 +144,7 @@ EXAMPLE
   Uploaded successfully!
 ```
 
-_See code: [src/commands/apply/resources.ts](https://github.com/Soluto/stitch/blob/v0.0.15/src/commands/apply/resources.ts)_
+_See code: [src/commands/apply/resources.ts](https://github.com/Soluto/stitch/blob/v0.0.17/src/commands/apply/resources.ts)_
 
 ## `stitch help [COMMAND]`
 
@@ -164,7 +161,7 @@ OPTIONS
   --all  see all commands in CLI
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v3.2.0/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v3.2.2/src/commands/help.ts)_
 
 ## `stitch refresh:remote-schema REMOTESERVERURL`
 
@@ -185,6 +182,6 @@ EXAMPLE
   Remote schema refreshed successfully!
 ```
 
-_See code: [src/commands/refresh/remote-schema.ts](https://github.com/Soluto/stitch/blob/v0.0.15/src/commands/refresh/remote-schema.ts)_
+_See code: [src/commands/refresh/remote-schema.ts](https://github.com/Soluto/stitch/blob/v0.0.17/src/commands/refresh/remote-schema.ts)_
 
 <!-- commandsstop -->

--- a/cli/README.md
+++ b/cli/README.md
@@ -77,6 +77,7 @@ args:
   - [Resources](#resources)
   - [Commands](#commands)
   - [`stitch apply:base-policy RESOURCEPATH`](#stitch-applybase-policy-resourcepath)
+  - [`stitch apply:introspection-query-policy RESOURCEPATH`](#stitch-applyintrospection-query-policy-resourcepath)
   - [`stitch apply:resources RESOURCESPATH`](#stitch-applyresources-resourcespath)
   - [`stitch help [COMMAND]`](#stitch-help-command)
   - [`stitch refresh:remote-schema REMOTESERVERURL`](#stitch-refreshremote-schema-remoteserverurl)
@@ -102,6 +103,28 @@ EXAMPLE
 ```
 
 _See code: [src/commands/apply/base-policy.ts](https://github.com/Soluto/stitch/blob/v0.0.15/src/commands/apply/base-policy.ts)_
+
+## `stitch apply:introspection-query-policy RESOURCEPATH`
+
+Apply introspection query policy
+
+```
+USAGE
+  $ stitch apply:introspection-query-policy RESOURCEPATH
+
+OPTIONS
+  --authorization-header=authorization-header  Custom authorization header
+  --dry-run                                    Should perform a dry run
+  --registry-url=registry-url                  (required) Url of the registry
+  --timeout=timeout                            [default: 10000] Request timeout
+
+EXAMPLE
+
+         $ stitch apply:introspection-query-policy introspection-query-policy.yaml
+         Uploaded successfully!
+```
+
+_See code: [src/commands/apply/introspection-query-policy.ts](https://github.com/Soluto/stitch/blob/v0.0.15/src/commands/apply/introspection-query-policy.ts)_
 
 ## `stitch apply:resources RESOURCESPATH`
 

--- a/cli/oclif.manifest.json
+++ b/cli/oclif.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.156",
+  "version": "0.0.17",
   "commands": {
     "apply:base-policy": {
       "id": "apply:base-policy",
@@ -8,6 +8,45 @@
       "pluginType": "core",
       "aliases": [],
       "examples": ["\n      $ stitch apply:base-policy base-policy.yaml\n      Uploaded successfully!\n    "],
+      "flags": {
+        "registry-url": {
+          "name": "registry-url",
+          "type": "option",
+          "description": "Url of the registry",
+          "required": true
+        },
+        "dry-run": {
+          "name": "dry-run",
+          "type": "boolean",
+          "description": "Should perform a dry run",
+          "required": false,
+          "allowNo": false
+        },
+        "authorization-header": {
+          "name": "authorization-header",
+          "type": "option",
+          "description": "Custom authorization header",
+          "required": false
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "option",
+          "description": "Request timeout",
+          "required": false,
+          "default": 10000
+        }
+      },
+      "args": [{ "name": "resourcePath", "required": true }]
+    },
+    "apply:introspection-query-policy": {
+      "id": "apply:introspection-query-policy",
+      "description": "Apply introspection query policy",
+      "pluginName": "stitch-cli",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "\n      $ stitch apply:introspection-query-policy introspection-query-policy.yaml\n      Uploaded successfully!\n    "
+      ],
       "flags": {
         "registry-url": {
           "name": "registry-url",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stitch-cli",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "author": "Aviv Rozenboim @AvivRubys",
   "repository": "Soluto/stitch",
   "homepage": "https://github.com/Soluto/stitch",

--- a/cli/src/client/index.ts
+++ b/cli/src/client/index.ts
@@ -1,5 +1,5 @@
 import { GraphQLClient, gql } from 'graphql-request';
-import { BasePolicyInput, ResourceGroupInput } from './types';
+import { BasePolicyInput, IntrospectionQueryPolicyInput, ResourceGroupInput } from './types';
 
 export interface RequestInit {
   body?: BodyInit | null;
@@ -46,6 +46,22 @@ const UploadBasePolicyMutation = gql`
 const ValidateBasePolicyQuery = gql`
   query ValidateBasePolicyQuery($basePolicy: BasePolicyInput!) {
     result: validateBasePolicy(input: $basePolicy) {
+      success
+    }
+  }
+`;
+
+const UploadIntrospectionQueryPolicyMutation = gql`
+  mutation UploadIntrospectionQueryPolicyMutation($introspectionQueryPolicy: IntrospectionQueryPolicyInput!) {
+    result: updateIntrospectionQueryPolicy(input: $introspectionQueryPolicy) {
+      success
+    }
+  }
+`;
+
+const ValidateIntrospectionQueryPolicyQuery = gql`
+  query ValidateIntrospectionQueryPolicyQuery($introspectionQueryPolicy: IntrospectionQueryPolicyInput!) {
+    result: validateIntrospectionQueryPolicy(input: $introspectionQueryPolicy) {
       success
     }
   }
@@ -103,6 +119,22 @@ export async function uploadBasePolicy(
   const query = options.dryRun ? ValidateBasePolicyQuery : UploadBasePolicyMutation;
 
   return registryClient.request<{ result: { success: boolean } }>(query, { basePolicy });
+}
+
+export async function uploadIntrospectionQueryPolicy(
+  introspectionQuery: IntrospectionQueryPolicyInput,
+  options: {
+    registryUrl: string;
+    dryRun?: boolean;
+    authorizationHeader?: string;
+  },
+  clientOptions: Partial<RequestInit>
+) {
+  const registryClient = initClient(options, clientOptions);
+
+  const query = options.dryRun ? ValidateIntrospectionQueryPolicyQuery : UploadIntrospectionQueryPolicyMutation;
+
+  return registryClient.request<{ result: { success: boolean } }>(query, { introspectionQuery });
 }
 
 export async function refreshRemoteSchema(

--- a/cli/src/client/types.ts
+++ b/cli/src/client/types.ts
@@ -67,6 +67,7 @@ export type Mutation = {
   updateUpstreamClientCredentials?: Maybe<Result>;
   updatePolicies?: Maybe<Result>;
   updateBasePolicy?: Maybe<Result>;
+  updateIntrospectionQueryPolicy?: Maybe<Result>;
 };
 
 export type MutationUpdateResourceGroupArgs = {
@@ -91,6 +92,10 @@ export type MutationUpdatePoliciesArgs = {
 
 export type MutationUpdateBasePolicyArgs = {
   input: BasePolicyInput;
+};
+
+export type MutationUpdateIntrospectionQueryPolicyArgs = {
+  input: IntrospectionQueryPolicyInput;
 };
 
 export type SchemaInput = {
@@ -157,6 +162,12 @@ export type PolicyInput = {
 };
 
 export type BasePolicyInput = {
+  namespace: Scalars['String'];
+  name: Scalars['String'];
+  args?: Maybe<Scalars['JSONObject']>;
+};
+
+export type IntrospectionQueryPolicyInput = {
   namespace: Scalars['String'];
   name: Scalars['String'];
   args?: Maybe<Scalars['JSONObject']>;

--- a/cli/src/commands/apply/introspection-query-policy.ts
+++ b/cli/src/commands/apply/introspection-query-policy.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import { safeLoad } from 'js-yaml';
 import Command, { flags } from '@oclif/command';
-import { BasePolicyInput, uploadBasePolicy } from '../../client';
+import { IntrospectionQueryPolicyInput, uploadIntrospectionQueryPolicy } from '../../client';
 import getEnvInfo from '../../utils/get-env-info';
 
 export default class ApplyIntrospectionQueryPolicy extends Command {
@@ -33,13 +33,13 @@ export default class ApplyIntrospectionQueryPolicy extends Command {
 
     try {
       this.log(`${dryRun ? 'Verifying' : 'Uploading'} introspection query policy from ${args.resourcePath}...`);
-      const basePolicyContent = await fs.readFile(args.resourcePath, { encoding: 'utf8' });
-      const basePolicy = safeLoad(basePolicyContent) as BasePolicyInput;
+      const introspectionQueryPolicyContent = await fs.readFile(args.resourcePath, { encoding: 'utf8' });
+      const introspectionQueryPolicy = safeLoad(introspectionQueryPolicyContent) as IntrospectionQueryPolicyInput;
 
       const {
         result: { success },
-      } = await uploadBasePolicy(
-        basePolicy,
+      } = await uploadIntrospectionQueryPolicy(
+        introspectionQueryPolicy,
         {
           registryUrl: flags['registry-url'],
           authorizationHeader: flags['authorization-header'],

--- a/cli/src/commands/apply/introspection-query-policy.ts
+++ b/cli/src/commands/apply/introspection-query-policy.ts
@@ -1,0 +1,74 @@
+import { promises as fs } from 'fs';
+import { safeLoad } from 'js-yaml';
+import Command, { flags } from '@oclif/command';
+import { BasePolicyInput, uploadBasePolicy } from '../../client';
+import getEnvInfo from '../../utils/get-env-info';
+
+export default class ApplyIntrospectionQueryPolicy extends Command {
+  static description = 'Apply introspection query policy';
+
+  static examples = [
+    `
+      $ stitch apply:introspection-query-policy introspection-query-policy.yaml
+      Uploaded successfully!
+    `,
+  ];
+
+  static flags = {
+    'registry-url': flags.string({ required: true, env: 'STITCH_REGISTRY_URL', description: 'Url of the registry' }),
+    'dry-run': flags.boolean({ required: false, default: false, description: 'Should perform a dry run' }),
+    'authorization-header': flags.string({ required: false, description: 'Custom authorization header' }),
+    timeout: flags.integer({ required: false, default: 10000, description: 'Request timeout' }),
+  };
+
+  static args = [{ name: 'resourcePath', required: true }];
+
+  async run() {
+    const { args, flags } = this.parse(ApplyIntrospectionQueryPolicy);
+    const dryRun = flags['dry-run'];
+
+    if (dryRun) {
+      this.log(`Dry run mode ON - No changes will be made to the registry`);
+    }
+
+    try {
+      this.log(`${dryRun ? 'Verifying' : 'Uploading'} introspection query policy from ${args.resourcePath}...`);
+      const basePolicyContent = await fs.readFile(args.resourcePath, { encoding: 'utf8' });
+      const basePolicy = safeLoad(basePolicyContent) as BasePolicyInput;
+
+      const {
+        result: { success },
+      } = await uploadBasePolicy(
+        basePolicy,
+        {
+          registryUrl: flags['registry-url'],
+          authorizationHeader: flags['authorization-header'],
+          dryRun,
+        },
+        {
+          timeout: flags.timeout,
+        }
+      );
+
+      if (success) {
+        this.log(
+          `introspection query policy from ${args.resourcePath} was ${dryRun ? 'verified' : 'uploaded'} successfully.`
+        );
+      } else {
+        throw new Error('Something went wrong');
+      }
+    } catch (e) {
+      this.error(
+        `${dryRun ? 'Verifying' : 'Uploading'} of introspection query policy failed. ${e}
+
+          ${getEnvInfo(
+            this.config,
+            'apply:introspection-query-policy',
+            flags['registry-url'],
+            flags['authorization-header']
+          )}`,
+        { ...e, exit: true }
+      );
+    }
+  }
+}

--- a/cli/tests/apply-introspection-query-policy.spec.ts
+++ b/cli/tests/apply-introspection-query-policy.spec.ts
@@ -1,0 +1,42 @@
+/* eslint-disable promise/valid-params */
+/* eslint-disable promise/catch-or-return */
+import { expect, test } from '@oclif/test';
+
+describe('Apply introspection policy', () => {
+  test
+    .nock('http://registry', api =>
+      api.post('/graphql').reply(200, {
+        data: {
+          result: {
+            success: true,
+          },
+        },
+      })
+    )
+    .stdout()
+    .command([
+      'apply:introspection-query-policy',
+      '--dry-run',
+      '--registry-url=http://registry/graphql',
+      'tests/data/introspection-query-policy/introspection-query-policy.yaml',
+    ])
+    .it('Verify', ctx => {
+      expect(ctx.stdout).to.contain('was verified successfully');
+    });
+
+  test
+    .nock('http://registry', api => api.post('/graphql').delay(100).reply(200))
+    .stdout()
+    .stderr()
+    .command([
+      'apply:introspection-query-policy',
+      '--dry-run',
+      '--registry-url=http://registry/graphql',
+      '--timeout=50',
+      'tests/data/introspection-query-policy/introspection-query-policy.yaml',
+    ])
+    .catch((e: Error) => expect(e.message).contains('network timeout at: http://registry/graphql'), {
+      raiseIfNotThrown: true,
+    })
+    .it('Timeout', () => {});
+});

--- a/cli/tests/data/introspection-query-policy/introspection-query-policy.yaml
+++ b/cli/tests/data/introspection-query-policy/introspection-query-policy.yaml
@@ -1,0 +1,2 @@
+namespace: employee-ns
+name: introspection-query-policy

--- a/services/src/modules/apollo-server-plugins/index.ts
+++ b/services/src/modules/apollo-server-plugins/index.ts
@@ -6,9 +6,12 @@ import { createLoggingPlugin } from './logging';
 import { createMetricsPlugin } from './metrics';
 
 export default function getPlugins(): PluginDefinition[] {
-  createIntrospectionQueryPolicyPlugin();
-
-  const baseApolloServerPlugins = [createBasicPolicyPlugin, createLoggingPlugin, createMetricsPlugin];
+  const baseApolloServerPlugins = [
+    createBasicPolicyPlugin,
+    createLoggingPlugin,
+    createMetricsPlugin,
+    createIntrospectionQueryPolicyPlugin,
+  ];
   const plugins = applyPluginsForApolloServerPlugins(baseApolloServerPlugins);
   return plugins;
 }

--- a/services/src/modules/apollo-server-plugins/index.ts
+++ b/services/src/modules/apollo-server-plugins/index.ts
@@ -1,10 +1,13 @@
 import { PluginDefinition } from 'apollo-server-core';
 import { transformApolloServerPlugins as applyPluginsForApolloServerPlugins } from '../plugins';
 import { createBasicPolicyPlugin } from './base-policy';
+import { createIntrospectionQueryPolicyPlugin } from './introspection-query-policy';
 import { createLoggingPlugin } from './logging';
 import { createMetricsPlugin } from './metrics';
 
 export default function getPlugins(): PluginDefinition[] {
+  createIntrospectionQueryPolicyPlugin();
+
   const baseApolloServerPlugins = [createBasicPolicyPlugin, createLoggingPlugin, createMetricsPlugin];
   const plugins = applyPluginsForApolloServerPlugins(baseApolloServerPlugins);
   return plugins;

--- a/services/src/modules/apollo-server-plugins/introspection-query-policy.ts
+++ b/services/src/modules/apollo-server-plugins/introspection-query-policy.ts
@@ -34,7 +34,7 @@ function wrapWithPolicyValidation(field: GraphQLField<unknown, RequestContext>) 
     let policy = introspectionQueryPolicy;
 
     if (!policy) {
-      logger.debug('Introspection query policy not found, using base policy');
+      logger.trace('Introspection query policy not found, using base policy');
       policy = basePolicy;
     }
 

--- a/services/src/modules/apollo-server-plugins/introspection-query-policy.ts
+++ b/services/src/modules/apollo-server-plugins/introspection-query-policy.ts
@@ -1,12 +1,11 @@
-import { GraphQLResolveInfo, SchemaMetaFieldDef } from 'graphql';
-import { ForbiddenError } from 'apollo-server-core';
+import { GraphQLResolveInfo, SchemaMetaFieldDef, TypeMetaFieldDef } from 'graphql';
 import logger from '../logger';
 import { RequestContext } from '../context';
 import { ResourceGroup } from '../resource-repository';
 import { ActiveDirectoryAuth } from '../upstreams/authentication';
 import { PolicyExecutor } from '../directives/policy';
 
-const INTROSPECTION_QUERY_FIELD_NAMES = new Set(['__schema', '__type']);
+const INTROSPECTION_QUERY_FIELD_NAMES = new Set([SchemaMetaFieldDef.name, TypeMetaFieldDef.name]);
 
 function isIntrospectionRequest(info: GraphQLResolveInfo) {
   return INTROSPECTION_QUERY_FIELD_NAMES.has(info.fieldName);
@@ -16,6 +15,15 @@ export function createIntrospectionQueryPolicyPlugin(): void {
   const originalSchemaMetaFieldResolver = SchemaMetaFieldDef.resolve;
 
   SchemaMetaFieldDef.resolve = function (source, args, context, info) {
+    function callOriginal() {
+      return originalSchemaMetaFieldResolver!.call(SchemaMetaFieldDef, source, args, context, info);
+    }
+
+    if (!context) {
+      // Apollo is sending introspection queries to generate schema hash, we can't and don't want to block that.
+      return callOriginal();
+    }
+
     const { resourceGroup, policyExecutor } = (context as unknown) as RequestContext;
     const { introspectionQueryPolicy, basePolicy } = resourceGroup;
 
@@ -28,12 +36,12 @@ export function createIntrospectionQueryPolicyPlugin(): void {
       }
 
       if (!policy) {
-        logger.info('Base policy not found, denying access by default');
-        throw new ForbiddenError('You are not authorized to perform this request.');
+        logger.info('Base policy not found, allowing access by default');
+        return callOriginal();
       }
 
       policyExecutor.validatePolicySync(policy, source, args, context, info);
-      return originalSchemaMetaFieldResolver!.call(SchemaMetaFieldDef, source, args, context, info);
+      return callOriginal();
     }
   };
 }

--- a/services/src/modules/apollo-server-plugins/introspection-query-policy.ts
+++ b/services/src/modules/apollo-server-plugins/introspection-query-policy.ts
@@ -1,0 +1,47 @@
+import { GraphQLResolveInfo, SchemaMetaFieldDef } from 'graphql';
+import { ForbiddenError } from 'apollo-server-core';
+import logger from '../logger';
+import { RequestContext } from '../context';
+import { ResourceGroup } from '../resource-repository';
+import { ActiveDirectoryAuth } from '../upstreams/authentication';
+import { PolicyExecutor } from '../directives/policy';
+
+const INTROSPECTION_QUERY_FIELD_NAMES = new Set(['__schema', '__type']);
+
+function isIntrospectionRequest(info: GraphQLResolveInfo) {
+  return INTROSPECTION_QUERY_FIELD_NAMES.has(info.fieldName);
+}
+
+export function createIntrospectionQueryPolicyPlugin(): void {
+  const originalSchemaMetaFieldResolver = SchemaMetaFieldDef.resolve;
+
+  SchemaMetaFieldDef.resolve = function (source, args, context, info) {
+    const { resourceGroup, policyExecutor } = (context as unknown) as RequestContext;
+    const { introspectionQueryPolicy, basePolicy } = resourceGroup;
+
+    if (isIntrospectionRequest(info)) {
+      let policy = introspectionQueryPolicy;
+
+      if (!policy) {
+        logger.info('Introspection query policy not found, using base policy');
+        policy = basePolicy;
+      }
+
+      if (!policy) {
+        logger.info('Base policy not found, denying access by default');
+        throw new ForbiddenError('You are not authorized to perform this request.');
+      }
+
+      policyExecutor.validatePolicySync(policy, source, args, context, info);
+      return originalSchemaMetaFieldResolver!.call(SchemaMetaFieldDef, source, args, context, info);
+    }
+  };
+}
+
+declare module '../context' {
+  interface RequestContext {
+    resourceGroup: ResourceGroup;
+    activeDirectoryAuth: ActiveDirectoryAuth;
+    policyExecutor: PolicyExecutor;
+  }
+}

--- a/services/src/modules/apollo-server-plugins/introspection-query-policy.ts
+++ b/services/src/modules/apollo-server-plugins/introspection-query-policy.ts
@@ -39,7 +39,7 @@ function wrapWithPolicyValidation(field: GraphQLField<unknown, RequestContext>) 
     }
 
     if (!policy) {
-      logger.debug('Base policy not found, allowing access by default');
+      logger.trace('Base policy not found, allowing access by default');
       return callOriginal();
     }
 

--- a/services/src/modules/apollo-server-plugins/introspection-query-policy.ts
+++ b/services/src/modules/apollo-server-plugins/introspection-query-policy.ts
@@ -28,8 +28,10 @@ function wrapWithPolicyValidation(field: GraphQLField<unknown, RequestContext>) 
       return callOriginal();
     }
 
-    const { resourceGroup, policyExecutor } = context as unknown as RequestContext;
-    const { introspectionQueryPolicy, basePolicy } = resourceGroup;
+    const {
+      resourceGroup: { introspectionQueryPolicy, basePolicy },
+      policyExecutor,
+    } = (context as unknown) as RequestContext;
 
     let policy = introspectionQueryPolicy;
 

--- a/services/src/modules/directives/policy/index.ts
+++ b/services/src/modules/directives/policy/index.ts
@@ -26,6 +26,7 @@ export type AuthorizationConfig = {
   policyAttachments?: Record<string, LoadedPolicy>;
   policyExecutor: PolicyExecutor;
   basePolicy?: Policy;
+  introspectionQueryPolicy?: Policy;
 };
 
 export const policyBaseSdl = gql`

--- a/services/src/modules/registry-schema/resolvers/get-resources.ts
+++ b/services/src/modules/registry-schema/resolvers/get-resources.ts
@@ -9,6 +9,7 @@ const resourcesByType: Record<ResourceType, (rg: ResourceGroup) => unknown> = {
   [ResourceType.DefaultUpstream]: rg => rg.defaultUpstream,
   [ResourceType.Policy]: rg => rg.policies,
   [ResourceType.BasePolicy]: rg => rg.basePolicy,
+  [ResourceType.IntrospectionQueryPolicy]: rg => rg.introspectionQueryPolicy,
 };
 
 export async function getResourcesByType(resourceType: ResourceType, fromGatewayResources = false) {

--- a/services/src/modules/registry-schema/resolvers/index.ts
+++ b/services/src/modules/registry-schema/resolvers/index.ts
@@ -2,6 +2,7 @@ import { IResolvers } from 'graphql-tools';
 import GraphQLJSON, { GraphQLJSONObject } from 'graphql-type-json';
 import {
   BasePolicyInput,
+  IntrospectionQueryPolicyInput,
   DefaultUpstreamInput,
   PolicyInput,
   ResourceGroupInput,
@@ -49,6 +50,9 @@ const resolvers: IResolvers = {
     basePolicy: (_, args: { fromGatewayResources?: boolean }) =>
       getResourcesByType(ResourceType.BasePolicy, args.fromGatewayResources),
 
+    introspectionQueryPolicy: (_, args: { fromGatewayResources?: boolean }) =>
+      getResourcesByType(ResourceType.IntrospectionQueryPolicy, args.fromGatewayResources),
+
     remoteSchemas: getRemoteSchemas,
     remoteSchema: (_, args: { url: string }) => getRemoteSchema(args.url),
 
@@ -69,6 +73,9 @@ const resolvers: IResolvers = {
 
     validateBasePolicy: (_, args: { input: BasePolicyInput }, context) =>
       handleUpdateResourceGroupRequest({ basePolicy: args.input }, context, true),
+
+    validateIntrospectionQueryPolicy: (_, args: { input: IntrospectionQueryPolicyInput }, context) =>
+      handleUpdateResourceGroupRequest({ introspectionQueryPolicy: args.input }, context, true),
 
     validateDefaultUpstream: (_, args: { input: DefaultUpstreamInput }, context) =>
       handleUpdateResourceGroupRequest({ defaultUpstream: args.input }, context, true),
@@ -95,6 +102,9 @@ const resolvers: IResolvers = {
     updateBasePolicy: (_, args: { input: BasePolicyInput }, context) =>
       handleUpdateResourceGroupRequest({ basePolicy: args.input }, context),
 
+    updateIntrospectionQueryPolicy: (_, args: { input: IntrospectionQueryPolicyInput }, context) =>
+      handleUpdateResourceGroupRequest({ introspectionQueryPolicy: args.input }, context),
+
     setDefaultUpstream: (_, args: { input: DefaultUpstreamInput }, context) =>
       handleUpdateResourceGroupRequest({ defaultUpstream: args.input }, context),
 
@@ -116,6 +126,9 @@ const resolvers: IResolvers = {
 
     deleteBasePolicy: (_, args: { input: boolean }, context) =>
       handleDeleteResourcesRequest({ basePolicy: args.input }, context),
+
+    deleteIntrospectionQueryPolicy: (_, args: { input: boolean }, context) =>
+      handleDeleteResourcesRequest({ introspectionQueryPolicy: args.input }, context),
 
     resetDefaultUpstream: (_, args: { input: boolean }, context) =>
       handleDeleteResourcesRequest({ defaultUpstream: args.input }, context),

--- a/services/src/modules/registry-schema/typedefs.ts
+++ b/services/src/modules/registry-schema/typedefs.ts
@@ -116,6 +116,7 @@ export default gql`
     policy(metadata: ResourceMetadataInput!, fromGatewayResources: Boolean): Policy
     policies(fromGatewayResources: Boolean): [Policy!]!
     basePolicy(fromGatewayResources: Boolean): BasePolicy
+    introspectionQueryPolicy(fromGatewayResources: Boolean): Policy
 
     remoteSchemas: [RemoteSchema!]!
     remoteSchema(url: String!): RemoteSchema

--- a/services/src/modules/registry-schema/typedefs.ts
+++ b/services/src/modules/registry-schema/typedefs.ts
@@ -76,6 +76,12 @@ export default gql`
     args: JSONObject
   }
 
+  type IntrospectionQueryPolicy {
+    namespace: String!
+    name: String!
+    args: JSONObject
+  }
+
   type RemoteSchema {
     url: String!
     schema: String!
@@ -116,7 +122,7 @@ export default gql`
     policy(metadata: ResourceMetadataInput!, fromGatewayResources: Boolean): Policy
     policies(fromGatewayResources: Boolean): [Policy!]!
     basePolicy(fromGatewayResources: Boolean): BasePolicy
-    introspectionQueryPolicy(fromGatewayResources: Boolean): Policy
+    introspectionQueryPolicy(fromGatewayResources: Boolean): IntrospectionQueryPolicy
 
     remoteSchemas: [RemoteSchema!]!
     remoteSchema(url: String!): RemoteSchema
@@ -127,6 +133,7 @@ export default gql`
     validateUpstreamClientCredentials(input: [UpstreamClientCredentialsInput!]!): Result
     validatePolicies(input: [PolicyInput!]!): Result
     validateBasePolicy(input: BasePolicyInput!): Result
+    validateIntrospectionQueryPolicy(input: IntrospectionQueryPolicyInput!): Result
     validateDefaultUpstream(input: DefaultUpstreamInput!): Result
   }
 
@@ -139,6 +146,7 @@ export default gql`
     updateUpstreamClientCredentials(input: [UpstreamClientCredentialsInput!]!): Result
     updatePolicies(input: [PolicyInput!]!): Result
     updateBasePolicy(input: BasePolicyInput!): Result
+    updateIntrospectionQueryPolicy(input: IntrospectionQueryPolicyInput!): Result
     setDefaultUpstream(input: DefaultUpstreamInput!): Result
 
     deleteResources(input: ResourceGroupMetadataInput!): Result
@@ -147,6 +155,7 @@ export default gql`
     deleteUpstreamClientCredentials(input: [ResourceMetadataInput!]!): Result
     deletePolicies(input: [ResourceMetadataInput!]!): Result
     deleteBasePolicy(input: Boolean!): Result
+    deleteIntrospectionQueryPolicy(input: Boolean!): Result
     resetDefaultUpstream(input: Boolean!): Result
 
     refreshRemoteSchema(url: String!): Result
@@ -238,6 +247,12 @@ export default gql`
   }
 
   input BasePolicyInput {
+    namespace: String!
+    name: String!
+    args: JSONObject
+  }
+
+  input IntrospectionQueryPolicyInput {
     namespace: String!
     name: String!
     args: JSONObject

--- a/services/src/modules/registry-schema/types.ts
+++ b/services/src/modules/registry-schema/types.ts
@@ -18,6 +18,7 @@ export enum ResourceType {
   DefaultUpstream,
   Policy,
   BasePolicy,
+  IntrospectionQueryPolicy,
 }
 
 export interface ResourceGroupMetadataInput {

--- a/services/src/modules/registry-schema/types.ts
+++ b/services/src/modules/registry-schema/types.ts
@@ -27,6 +27,7 @@ export interface ResourceGroupMetadataInput {
   upstreamClientCredentials?: ResourceMetadataInput[];
   policies?: ResourceMetadataInput[];
   basePolicy?: boolean;
+  introspectionQueryPolicy?: boolean;
   defaultUpstream?: boolean;
 }
 
@@ -38,6 +39,7 @@ export interface ResourceGroupInput {
   upstreamClientCredentials?: UpstreamClientCredentialsInput[];
   policies?: PolicyInput[];
   basePolicy?: BasePolicyInput;
+  introspectionQueryPolicy?: IntrospectionQueryPolicyInput;
   defaultUpstream?: DefaultUpstreamInput;
 }
 
@@ -95,6 +97,12 @@ export interface PolicyInput {
 }
 
 export interface BasePolicyInput {
+  namespace: string;
+  name: string;
+  args?: PolicyArgsObject;
+}
+
+export interface IntrospectionQueryPolicyInput {
   namespace: string;
   name: string;
   args?: PolicyArgsObject;

--- a/services/src/modules/resource-repository/actions/delete.ts
+++ b/services/src/modules/resource-repository/actions/delete.ts
@@ -44,6 +44,10 @@ export default function applyResourceGroupDeletions(
     newRg.basePolicy = undefined;
   }
 
+  if (deletions.introspectionQueryPolicy) {
+    newRg.introspectionQueryPolicy = undefined;
+  }
+
   if (deletions.defaultUpstream) {
     newRg.defaultUpstream = undefined;
   }

--- a/services/src/modules/resource-repository/actions/update.ts
+++ b/services/src/modules/resource-repository/actions/update.ts
@@ -53,6 +53,10 @@ export default function applyResourceGroupUpdates(rg: ResourceGroup, update: Par
     newRg.basePolicy = update.basePolicy;
   }
 
+  if (typeof update.introspectionQueryPolicy !== 'undefined') {
+    newRg.introspectionQueryPolicy = update.introspectionQueryPolicy;
+  }
+
   if (typeof update.defaultUpstream !== 'undefined') {
     newRg.defaultUpstream = update.defaultUpstream;
   }

--- a/services/src/modules/resource-repository/types.ts
+++ b/services/src/modules/resource-repository/types.ts
@@ -15,6 +15,7 @@ export interface ResourceGroup {
   // policyAttachments are compiled from the Rego code in opa policies, they are not directly modified by users
   policyAttachments?: PolicyAttachments;
   basePolicy?: Policy;
+  introspectionQueryPolicy?: Policy;
   defaultUpstream?: DefaultUpstream;
   remoteSchemas?: RemoteSchema[];
   pluginsData?: Record<string, any>;
@@ -35,6 +36,7 @@ export interface ResourceGroupMetadata {
   upstreamClientCredentials: ResourceMetadata[];
   policies: ResourceMetadata[];
   basePolicy: boolean;
+  introspectionQueryPolicy: boolean;
   defaultUpstream: boolean;
 }
 

--- a/services/tests/helpers/registry-request-builder.ts
+++ b/services/tests/helpers/registry-request-builder.ts
@@ -25,6 +25,14 @@ export const updateBasePolicyMutation = print(gql`
   }
 `);
 
+export const updateIntrospectionQueryPolicyMutation = print(gql`
+  mutation UpdateIntrospectionQueryPolicy($introspectionQueryPolicy: IntrospectionQueryPolicyInput!) {
+    result: updateIntrospectionQueryPolicy(input: $introspectionQueryPolicy) {
+      success
+    }
+  }
+`);
+
 export const updateResourceGroupMutation = print(gql`
   mutation UpdateResourceGroupMutation($resourceGroup: ResourceGroupInput!) {
     result: updateResourceGroup(input: $resourceGroup) {

--- a/services/tests/integration/gateway/introspection-query-policy.spec.ts
+++ b/services/tests/integration/gateway/introspection-query-policy.spec.ts
@@ -27,11 +27,10 @@ const introspectionQueryPolicy: Policy = {
   name: 'introspection_query_policy',
 };
 
-const testCases: [string, ResourceGroup & { etag: string }, DocumentNode | string, boolean][] = [
+const testCases: [string, ResourceGroup, DocumentNode | string, boolean][] = [
   [
     'Deny on introspection query policy',
     {
-      etag: 'etag1',
       introspectionQueryPolicy,
       policies,
       policyAttachments: {
@@ -59,7 +58,6 @@ const testCases: [string, ResourceGroup & { etag: string }, DocumentNode | strin
   [
     'Allow on introspection query policy',
     {
-      etag: 'etag2',
       introspectionQueryPolicy,
       policies,
       policyAttachments: {
@@ -85,9 +83,31 @@ const testCases: [string, ResourceGroup & { etag: string }, DocumentNode | strin
     true,
   ],
   [
+    'Allow when no introspection query policy was configured',
+    {
+      policies,
+      upstreams: [],
+      upstreamClientCredentials: [],
+      schemas: [
+        {
+          metadata: {
+            namespace: 'ns',
+            name: 'main',
+          },
+          schema: print(gql`
+            type Query {
+              bar: String @localResolver(value: "BAR")
+            }
+          `),
+        },
+      ],
+    },
+    getIntrospectionQuery(),
+    true,
+  ],
+  [
     'Deny on introspection query when using alias',
     {
-      etag: 'etag3',
       introspectionQueryPolicy,
       policies,
       policyAttachments: {

--- a/services/tests/integration/gateway/introspection-query-policy.spec.ts
+++ b/services/tests/integration/gateway/introspection-query-policy.spec.ts
@@ -1,0 +1,204 @@
+import { ApolloServerTestClient, createTestClient } from 'apollo-server-testing';
+import { DocumentNode, print } from 'graphql';
+import { gql } from 'apollo-server-core';
+import { getIntrospectionQuery } from 'graphql/utilities';
+import createStitchGateway from '../../../src/modules/apollo-server';
+import { ResourceGroup, PolicyDefinition, PolicyType } from '../../../src/modules/resource-repository';
+import { beforeEachDispose } from '../before-each-dispose';
+import { Policy } from '../../../src/modules/directives/policy/types';
+import { mockLoadedPolicy } from '../../helpers/opa-utility';
+import getResourceRepository from '../../../src/modules/resource-repository/get-resource-repository';
+import { UnauthorizedByPolicyError } from '../../../src/modules/directives/policy';
+
+jest.mock('../../../src/modules/resource-repository/get-resource-repository');
+
+const policies: PolicyDefinition[] = [
+  {
+    metadata: {
+      namespace: 'internal',
+      name: 'base_policy',
+    },
+    type: PolicyType.opa,
+    code: `Rego code`,
+  },
+  {
+    metadata: {
+      namespace: 'internal',
+      name: 'introspection_query_policy',
+    },
+    type: PolicyType.opa,
+    code: `Rego code`,
+  },
+];
+
+const basePolicy: Policy = {
+  namespace: 'internal',
+  name: 'base_policy',
+};
+
+const introspectionQueryPolicy: Policy = {
+  namespace: 'internal',
+  name: 'introspection_query_policy',
+};
+
+const testCases: [string, ResourceGroup & { etag: string }, DocumentNode | string, boolean][] = [
+  [
+    'Deny on introspection query policy',
+    {
+      etag: 'etag1',
+      basePolicy,
+      introspectionQueryPolicy,
+      policies,
+      policyAttachments: {
+        ['internal-introspection_query_policy.wasm']: mockLoadedPolicy(false),
+        ['internal-base_policy.wasm']: mockLoadedPolicy(true),
+      },
+      upstreams: [],
+      upstreamClientCredentials: [],
+      schemas: [
+        {
+          metadata: {
+            namespace: 'ns',
+            name: 'main',
+          },
+          schema: print(gql`
+            type Query {
+              bar: String @localResolver(value: "BAR")
+            }
+          `),
+        },
+      ],
+    },
+    getIntrospectionQuery(),
+    true,
+  ],
+  [
+    'Allow on introspection query policy',
+    {
+      etag: 'etag2',
+      basePolicy,
+      introspectionQueryPolicy,
+      policies,
+      policyAttachments: {
+        ['internal-introspection_query_policy.wasm']: mockLoadedPolicy(true),
+        ['internal-base_policy.wasm']: mockLoadedPolicy(true),
+      },
+      upstreams: [],
+      upstreamClientCredentials: [],
+      schemas: [
+        {
+          metadata: {
+            namespace: 'ns',
+            name: 'main',
+          },
+          schema: print(gql`
+            type Query {
+              bar: String @localResolver(value: "BAR")
+            }
+          `),
+        },
+      ],
+    },
+    getIntrospectionQuery(),
+    false,
+  ],
+  [
+    'Allow on base policy, introspection query not configured',
+    {
+      etag: 'etag3',
+      basePolicy,
+      policies,
+      policyAttachments: {
+        ['internal-base_policy.wasm']: mockLoadedPolicy(true),
+      },
+      upstreams: [],
+      upstreamClientCredentials: [],
+      schemas: [
+        {
+          metadata: {
+            namespace: 'ns',
+            name: 'main',
+          },
+          schema: print(gql`
+            type Query {
+              bar: String @localResolver(value: "BAR")
+            }
+          `),
+        },
+      ],
+    },
+    getIntrospectionQuery(),
+    false,
+  ],
+  [
+    'Deny on introspection query when using alias',
+    {
+      etag: 'etag3',
+      basePolicy,
+      introspectionQueryPolicy,
+      policies,
+      policyAttachments: {
+        ['internal-introspection_query_policy.wasm']: mockLoadedPolicy(false),
+        ['internal-base_policy.wasm']: mockLoadedPolicy(true),
+      },
+      upstreams: [],
+      upstreamClientCredentials: [],
+      schemas: [
+        {
+          metadata: {
+            namespace: 'ns',
+            name: 'main',
+          },
+          schema: print(gql`
+            type Query {
+              bar: String @localResolver(value: "BAR")
+            }
+          `),
+        },
+      ],
+    },
+    gql`
+      query {
+        alias: __schema {
+          types {
+            name
+          }
+        }
+      }
+    `,
+    true,
+  ],
+];
+
+describe.each(testCases)('Introspection Query Policy Tests', (testName, resourceGroup, query, shouldThrow) => {
+  let client: ApolloServerTestClient;
+
+  const defaultIntrospectionQuery = getIntrospectionQuery();
+
+  beforeEachDispose(async () => {
+    (getResourceRepository as jest.Mock).mockImplementation(
+      jest.fn().mockReturnValue({
+        fetchLatest: () => Promise.resolve({ resourceGroup, isNew: true }),
+      })
+    );
+
+    const { server } = await createStitchGateway();
+    client = createTestClient(server);
+
+    return () => {
+      (getResourceRepository as jest.Mock).mockReset();
+      return server.stop();
+    };
+  });
+
+  test(testName, async () => {
+    const promise = client.query({ query: query || defaultIntrospectionQuery });
+
+    if (shouldThrow) {
+      await expect(promise).rejects.toThrow(UnauthorizedByPolicyError);
+    } else {
+      const response = await promise;
+      expect(response.data).toMatch('__schema');
+    }
+  });
+});


### PR DESCRIPTION
Currently stitch exposes `GRAPHQL_INTROSPECTION` with a default of `true`.
Enabling the introspection query in production is a security vulnerability in some use cases, so we want to control access to the introspection query using a policy instead.
If the introspection query is not provided, it will be allowed by default (assuming `GRAPHQL_INTROSPECTION` is true).